### PR TITLE
breaking(android): move clearAllNotifications to destroy from pause

### DIFF
--- a/src/android/com/adobe/phonegap/push/PushPlugin.java
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.java
@@ -510,12 +510,6 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
   public void onPause(boolean multitasking) {
     super.onPause(multitasking);
     gForeground = false;
-
-    SharedPreferences prefs = getApplicationContext().getSharedPreferences(COM_ADOBE_PHONEGAP_PUSH,
-        Context.MODE_PRIVATE);
-    if (prefs.getBoolean(CLEAR_NOTIFICATIONS, true)) {
-      clearAllNotifications();
-    }
   }
 
   @Override
@@ -529,6 +523,12 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
     super.onDestroy();
     gForeground = false;
     gWebView = null;
+    
+    SharedPreferences prefs = getApplicationContext().getSharedPreferences(COM_ADOBE_PHONEGAP_PUSH,
+        Context.MODE_PRIVATE);
+    if (prefs.getBoolean(CLEAR_NOTIFICATIONS, true)) {
+      clearAllNotifications();
+    }
   }
 
   private void clearAllNotifications() {


### PR DESCRIPTION
> Notifications should persist when the app is moved to the background in order to draw the user back to re-activate the app when they are done multitasking.
>
> Notifications should be destroyed when the all is closed though to avoid clutter.