### PR TITLE
breaking(android): bump fcm@18.+

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -160,7 +160,7 @@ To make the two work together, you need to migrate your GCM project from Google 
 
 _Note:_ No changes on the back-end side are needed: [even though recommended](https://developers.google.com/cloud-messaging/android/android-migrate-fcm#update_server_endpoints), it isn't yet required and sending messages through GCM gateway should work just fine.
 
-_Note:_ The `FCM_VERSION` must be greater than or equal to 7.1.0 and less than or equal to 18.0.0.
+_Note:_ The `FCM_VERSION` must be greater than or equal to 17.1.0 and less than or equal to 18.0.0.
 
 ### Common errors
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -137,20 +137,30 @@ cordova plugin add --save cordova-plugin-facebook4 --variable APP_ID="App ID" --
 
 ### Co-existing with plugins that use Firebase
 
-Problems may arise when push plugin is used along plugins that implement Firebase functionality (cordova-plugin-firebase-analytics, for example). Both plugins include a version of the FCM libraries.
+Problems may arise when push plugin is used along plugins that implement Firebase functionality (e.g. `cordova-plugin-firebase-analytics`). Both plugins include a version of the FCM libraries.
 
 To make the two work together, you need to migrate your GCM project from Google console to Firebase console:
 
-1.  In Firebase console - [import your existing GCM project](https://firebase.google.com/support/guides/google-android#migrate_your_console_project), don't create a new one.
-2.  Set your `FCM_VERSION` variable to match the version used in the other plugin. In case of cordova, your `config.xml` would look something like this:
+1. In Firebase console - [import your existing GCM project](https://firebase.google.com/support/guides/google-android#migrate_your_console_project), don't create a new one.
+2. Set your `FCM_VERSION` variable to match the version used in the other plugin. In case of Cordova, your `package.json` contains something like this:
 
-```xml
-<plugin name="phonegap-plugin-push" spec="~2.2.0">
-    <variable name="FCM_VERSION" value="15.0.0" />
-</plugin>
+```json
+{
+  "cordova": {
+    "plugins": {
+      "cordova-plugin-push": {
+        "ANDROID_SUPPORT_V13_VERSION": "27.+",
+        "FCM_VERSION": "18.+"
+      }
+    },
+    "platforms": []
+  }
+}
 ```
 
 _Note:_ No changes on the back-end side are needed: [even though recommended](https://developers.google.com/cloud-messaging/android/android-migrate-fcm#update_server_endpoints), it isn't yet required and sending messages through GCM gateway should work just fine.
+
+_Note:_ The `FCM_VERSION` must be greater than or equal to 7.1.0 and less than or equal to 18.0.0.
 
 ### Common errors
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -57,7 +57,7 @@
     </config-file>
 
     <preference name="ANDROID_SUPPORT_V13_VERSION" default="28.0.0"/>
-    <preference name="FCM_VERSION" default="17.0.+"/>
+    <preference name="FCM_VERSION" default="18.+"/>
 
     <framework src="com.android.support:support-v13:$ANDROID_SUPPORT_V13_VERSION"/>
     <framework src="me.leolin:ShortcutBadger:1.1.17@aar"/>

--- a/src/android/com/adobe/phonegap/push/PushInstanceIDListenerService.java
+++ b/src/android/com/adobe/phonegap/push/PushInstanceIDListenerService.java
@@ -6,21 +6,33 @@ import android.content.SharedPreferences;
 import android.util.Log;
 
 import com.google.firebase.iid.FirebaseInstanceId;
-import com.google.firebase.iid.FirebaseInstanceIdService;
+import com.google.firebase.iid.InstanceIdResult;
+import com.google.firebase.messaging.FirebaseMessagingService;
+import com.google.android.gms.tasks.OnSuccessListener;
 
 import org.json.JSONException;
 
 import java.io.IOException;
 
-public class PushInstanceIDListenerService extends FirebaseInstanceIdService implements PushConstants {
-    public static final String LOG_TAG = "Push_InsIdService";
+public class PushInstanceIDListenerService extends FirebaseMessagingService implements PushConstants {
+  public static final String LOG_TAG = "Push_InsIdService";
 
-    @Override
-    public void onTokenRefresh() {
+  @Override
+  public void onNewToken(String s) {
+    super.onNewToken(s);
+
+    FirebaseInstanceId.getInstance().getInstanceId()
+      .addOnSuccessListener(new OnSuccessListener<InstanceIdResult>() {
+      @Override
+      public void onSuccess(InstanceIdResult instanceIdResult) {
         // Get updated InstanceID token.
-        String refreshedToken = FirebaseInstanceId.getInstance().getToken();
+        String refreshedToken = instanceIdResult.getToken();
+
         Log.d(LOG_TAG, "Refreshed token: " + refreshedToken);
+
         // TODO: Implement this method to send any registration to your app's servers.
         //sendRegistrationToServer(refreshedToken);
-    }
+      }
+    });
+  }
 }


### PR DESCRIPTION
This bumps the Android's Firebase Cloud Messaging version to 18.+.
This is the latest and last version that supports the Android Support Libraries.