### PR TITLE
chore(android): bump com.android.support:support-v13:28.0.0

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -56,7 +56,7 @@
       <preference name="GradlePluginGoogleServicesVersion" value="4.2.0" />
     </config-file>
 
-    <preference name="ANDROID_SUPPORT_V13_VERSION" default="27.+"/>
+    <preference name="ANDROID_SUPPORT_V13_VERSION" default="28.0.0"/>
     <preference name="FCM_VERSION" default="17.0.+"/>
 
     <framework src="com.android.support:support-v13:$ANDROID_SUPPORT_V13_VERSION"/>


### PR DESCRIPTION
This bumps the com.android.support:support-v13 to version 28.0.0 which is the latest and last release that will be released for the Android Support Library.

Any newer versions would require AndroidX.