### PR TITLE
breaking(android): drop phonegap-plugin-multidex dependency

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -63,8 +63,6 @@
     <framework src="me.leolin:ShortcutBadger:1.1.17@aar"/>
     <framework src="com.google.firebase:firebase-messaging:$FCM_VERSION"/>
 
-    <dependency id="phonegap-plugin-multidex" version="~1.0.0"/>
-
     <source-file src="src/android/com/adobe/phonegap/push/FCMService.java" target-dir="src/com/adobe/phonegap/push/"/>
     <source-file src="src/android/com/adobe/phonegap/push/PushConstants.java" target-dir="src/com/adobe/phonegap/push/"/>
     <source-file src="src/android/com/adobe/phonegap/push/PushHandlerActivity.java" target-dir="src/com/adobe/phonegap/push/"/>


### PR DESCRIPTION
* https://developer.android.com/studio/build/multidex

> Multidex support for Android 5.0 and higher
>
> Android 5.0 (API level 21) and higher uses a runtime called ART which natively supports loading multiple DEX files from APK files. ART performs pre-compilation at app install time which scans for classesN.dex files and compiles them into a single .oat file for execution by the Android device. **Therefore, if your minSdkVersion is 21 or higher multidex is enabled by default, and you do not need the multidex support library.**

By default, `cordova-android` 9.x defines the `minSdkVersion` as `22` by default. 
This plugin support `cordova-android >= 9.x`.