### PR TITLE
chore(npm): properly configure for scope package

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -146,7 +146,7 @@ To make the two work together, you need to migrate your GCM project from Google 
 {
   "cordova": {
     "plugins": {
-      "cordova-plugin-push": {
+      "havesource-cordova-plugin-push": {
         "ANDROID_SUPPORT_V13_VERSION": "27.+",
         "FCM_VERSION": "18.+"
       }
@@ -291,8 +291,8 @@ This plugin uses the [Firebase/Messaging](https://cocoapods.org/pods/Firebase) l
 If you are attempting to install this plugin and you run into this error:
 
 ```log
-Installing "cordova-plugin-push" for ios
-Failed to install 'cordova-plugin-push':Error: pod: Command failed with exit code 1
+Installing "havesource-cordova-plugin-push" for ios
+Failed to install 'havesource-cordova-plugin-push':Error: pod: Command failed with exit code 1
     at ChildProcess.whenDone (/Users/smacdona/code/push151/platforms/ios/cordova/node_modules/cordova-common/src/superspawn.js:169:23)
     at emitTwo (events.js:87:13)
     at ChildProcess.emit (events.js:172:7)

--- a/hooks/browser/updateManifest.js
+++ b/hooks/browser/updateManifest.js
@@ -24,7 +24,7 @@ module.exports = function (context) {
 
     var pluginManifestPath = path.join(
       context.opts.projectRoot,
-      'plugins/cordova-plugin-push/src/browser/manifest.json'
+      'plugins/havesource-cordova-plugin-push/src/browser/manifest.json'
     );
 
     fs.readFile(pluginManifestPath, 'utf8', function (err, pluginJson) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "cordova-plugin-push",
+  "name": "@havesource/cordova-plugin-push",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cordova-plugin-push",
+  "name": "@havesource/cordova-plugin-push",
   "version": "1.0.0",
   "description": "Register and receive push notifications.",
   "scripts": {
@@ -47,7 +47,7 @@
   },
   "types": "./types/index.d.ts",
   "cordova": {
-    "id": "cordova-plugin-push",
+    "id": "havesource-cordova-plugin-push",
     "platforms": [
       "ios",
       "android",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
   xmlns:android="http://schemas.android.com/apk/res/android"
-  id="cordova-plugin-push" version="1.0.0">
+  id="havesource-cordova-plugin-push" version="1.0.0">
 
   <name>Cordova Push Plugin</name>
   <description>Enable receiving push notifications on Android, iOS and Windows devices. Android uses Firebase Cloud Messaging. iOS uses Apple APNS Notifications. Windows uses Microsoft WNS Notifications.</description>


### PR DESCRIPTION
## Motivation, Context & Description

closes: #17 

### Initial Release 1.0.0

This plugin is going to be scoped in the npmjs registry.

When installing this plugin, once released, the command would be:

```bash
cordova plugin add @havesource/cordova-plugin-push
```

Since the initial plugin release will support Cordova CLI `>= 9.0.0`, not all areas can be properly scoped. (E.g. `plugin.xml` etc)

This means to remove the plugin, the following command must be used:

```bash
cordova plugin rm havesource-cordova-plugin-push
```

As you notice, the plugin name is not scoped in this case.

### Second Release 2.0.0

I am also planning to release 2.x shortly after 1.x. The goal of 2.x is to start support from Cordova CLI >= 10.0.0.

Cordova 10 provides full support of scoped packages. This means the adding and removing command would use the scopped key `@havesource/cordova-plugin-push`

A few other things will change, but I will plan to document the  differences later.

Preferably everyone would be on Cordova 10 and starts with v2 of the plugin.

## How Has This Been Tested?

- n/a

## Screenshots (if appropriate):

- n/a
