### PR TITLE
feat(ios): increase firebase framework to 6.32.2

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -122,7 +122,7 @@
       <!-- keep empty `config` object to prevent `cordova-common` install issues.-->
       <config></config>
       <pods use-frameworks="true">
-        <pod name="Firebase/Messaging" spec="~> 6.31.0" />
+        <pod name="Firebase/Messaging" spec="~> 6.32.2" />
       </pods>
     </podspec>
   </platform>


### PR DESCRIPTION
Plugin cannot be installed in parallel w/ https://github.com/chemerisuk/cordova-plugin-firebase-analytics because of incompatible Firebase SDK versions.

## Description
As proposed by @rdesimone https://github.com/chemerisuk/cordova-plugin-firebase-analytics/issues/167#issuecomment-704920606 I updated the version. Both plugins can not be installed at the same time.

## Related Issue
#41 

## Motivation and Context
We need to use both plugins in the same customer app.

## How Has This Been Tested?
Updated framework version, cleaned my cordova project, re-added platforms, build app, installed app on iOS and Android test devices, allowed them to receive push notifications, send notification to test devices.

cleaning steps
1. rm -rf node_modules
2. rm -rf platforms
3. rm -rf plugins
4. pod repo update
5. npm install --no-optional
6. npm cordova platform rm android
7. npm cordova platform rm ios
8. npm cordova platform add android@9.0.0
9. npm cordova platform add ios@6.1.1
10. cd platforms/ios
11. pod install

<!--## Screenshots (if appropriate):-->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
