### PR TITLE
feat(ios): support firebase/messaging dep version override

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -91,6 +91,8 @@
   </platform>
 
   <platform name="ios">
+    <preference name="IOS_FIREBASE_MESSAGING_VERSION" default="~> 6.32.2"/>
+
     <config-file target="config.xml" parent="/*">
       <feature name="PushNotification">
         <param name="ios-package" value="PushPlugin"/>
@@ -122,7 +124,7 @@
       <!-- keep empty `config` object to prevent `cordova-common` install issues.-->
       <config></config>
       <pods use-frameworks="true">
-        <pod name="Firebase/Messaging" spec="~> 6.32.2" />
+        <pod name="Firebase/Messaging" spec="$IOS_FIREBASE_MESSAGING_VERSION" />
       </pods>
     </podspec>
   </platform>


### PR DESCRIPTION
## Motivation, Context & Description

Allow the iOS Firebase/Messaging dependency version to be overridable.

## Related Issue

N/A

## How Has This Been Tested?

- `cordova plugin add github:havesource/cordova-plugin-push\#feat/ios-dep-override`
  - Reviewed the Podfile to ensure the default "~> 6.32.2" is set.
- `cordova plugin add github:havesource/cordova-plugin-push\#feat/ios-dep-override --variable IOS_FIREBASE_MESSAGING_VERSION="~> 6.31.0"`
  - Reviewed the Podfile to ensure that "~> 6.31.0" is set.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
  - Will be handled in a seperate PR as there will be a refactor of the install docs.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
