### PR TITLE
fix(android): Use app name for default channel

### DIFF
--- a/src/android/com/adobe/phonegap/push/PushPlugin.java
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.java
@@ -167,7 +167,9 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
       }
       try {
         options.put(CHANNEL_ID, DEFAULT_CHANNEL_ID);
-        options.putOpt(CHANNEL_DESCRIPTION, "PhoneGap PushPlugin");
+        String appName = (String) this.cordova.getActivity().getPackageManager()
+          .getApplicationLabel(this.cordova.getActivity().getApplicationInfo());
+        options.putOpt(CHANNEL_DESCRIPTION, appName);
         createChannel(options);
       } catch (JSONException e) {
         Log.e(LOG_TAG, "execute: Got JSON Exception " + e.getMessage());


### PR DESCRIPTION
## Description
Change the default channel name to the app name.

## Related Issue
[phonegap#2691](https://github.com/phonegap/phonegap-plugin-push/issues/2691)
_(Hope it is okay to link to issues in the original plugin instead of opening one here.)_

## Motivation and Context
The default channel name on android is `PhoneGap PushPlugin`.
This name is visible e.g. in the notification settings of the app, which could be confusing.
To prevent this the user would be required to create a channel with a custom name.
Instead of this the plugin could also provide a better default e.g. the app name.

## How Has This Been Tested?
Tested on multiple android devices.
_(Already used this in production in a fork of the original plugin.)_

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
