### PR TITLE
chore(android): set requirement >= 8.0.0

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -2,6 +2,7 @@
 
 - [Installation](#installation)
   - [Installation Requirements](#installation-requirements)
+    - [Cordova Android 8.x Specifics](#cordova-android-8x-specifics)
   - [Android details](#android-details)
     - [Co-existing with Facebook Plugin](#co-existing-with-facebook-plugin)
     - [Co-existing with plugins that use Firebase](#co-existing-with-plugins-that-use-firebase)
@@ -74,6 +75,22 @@ By default, on iOS, the plugin will register with APNS. If you want to use FCM o
 ```xml
 <plugin name="@havesource/cordova-plugin-push" spec="1.0.0" />
 ```
+
+### Cordova Android 8.x Specifics
+
+You will need to install the `cordova-support-google-services` plugin. This plugin enables the Google APIs and Firebase services for your Android application.
+
+If your application uses many plugins and references over 64K methods, you will need to enable multidex. If multidex is not enabled, your build should fail and you should see the following error:
+
+```log
+trouble writing output:
+Too many field references: 131000; max is 65536.
+You may try using --multi-dex option.
+```
+
+To enable multidex, use the  `phonegap-plugin-multidex` plugin.
+
+These two plugins are only necessary for the Cordova Android 8.x releases.
 
 ## Android details
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "cordovaDependencies": {
       "1.0.0": {
         "cordova": ">=9.0.0",
-        "cordova-android": ">=9.0.0",
+        "cordova-android": ">=8.0.0",
         "cordova-ios": ">=5.1.1"
       }
     }

--- a/plugin.xml
+++ b/plugin.xml
@@ -14,7 +14,7 @@
 
   <engines>
     <engine name="cordova" version=">=9.0.0"/>
-    <engine name="cordova-android" version=">=9.0.0"/>
+    <engine name="cordova-android" version=">=8.0.0"/>
     <engine name="cordova-ios" version=">=5.1.1"/>
   </engines>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Set the Cordova Android requirement to `>= 8.0.0` for this short lived release.

## Related Issue

closes #36

## Motivation and Context

For the initial, short lived, release, we will continue to support `cordova-android >= 8.0.0`. This will be only for the first release major 1.x.

Starting from the second major release, 2.x, the `cordova-android` requirements will be set back to `>=9.0.0`. Anyone who can not use Cordova-Android 9.x or greater will be locked in to 1.x major release.

## How Has This Been Tested?

n/a

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
