### PR TITLE
fix(android): missing channel description crash

### DIFF
--- a/src/android/com/adobe/phonegap/push/PushPlugin.java
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.java
@@ -57,6 +57,14 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
     return this.cordova.getActivity().getApplicationContext();
   }
 
+  private String getAppName () {
+    return (String) this.cordova.getActivity()
+      .getPackageManager()
+      .getApplicationLabel(
+        this.cordova.getActivity().getApplicationInfo()
+      );
+  }
+
   @TargetApi(26)
   private JSONArray listChannels () throws JSONException {
     JSONArray channels = new JSONArray();
@@ -93,9 +101,10 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
         .getSystemService(Context.NOTIFICATION_SERVICE);
 
       String packageName = getApplicationContext().getPackageName();
+      String appName = this.getAppName();
       NotificationChannel mChannel = new NotificationChannel(
         channel.getString(CHANNEL_ID),
-        channel.optString(CHANNEL_DESCRIPTION, ""),
+        channel.optString(CHANNEL_DESCRIPTION, appName),
         channel.optInt(CHANNEL_IMPORTANCE, NotificationManager.IMPORTANCE_DEFAULT)
       );
 
@@ -167,8 +176,7 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
       }
       try {
         options.put(CHANNEL_ID, DEFAULT_CHANNEL_ID);
-        String appName = (String) this.cordova.getActivity().getPackageManager()
-          .getApplicationLabel(this.cordova.getActivity().getApplicationInfo());
+        String appName = this.getAppName();
         options.putOpt(CHANNEL_DESCRIPTION, appName);
         createChannel(options);
       } catch (JSONException e) {
@@ -568,8 +576,7 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
   private void clearNotification (int id) {
     final NotificationManager notificationManager = (NotificationManager) cordova.getActivity()
       .getSystemService(Context.NOTIFICATION_SERVICE);
-    String appName = (String) this.cordova.getActivity().getPackageManager()
-      .getApplicationLabel(this.cordova.getActivity().getApplicationInfo());
+    String appName = this.getAppName();
     notificationManager.cancel(appName, id);
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes missing channel description causing Android app to crash.

* This PR also created the `getAppName` method to centralize the code that has been used in 3 areas of the class to get the app name.

## Related Issue

n/a

## Motivation and Context

Instead of crashing the app when the user forgets to add a channel description, have it fallback to the app's name.

Even though the channel description property is a required field, I feel it would be safer to fall back to the app name so that the app wont crash because the user forgot to add a custom description. 

## How Has This Been Tested?

First I created a blank hello world app with a new channel

```js
PushNotification.createChannel(
  () => { console.log('success'); },
  () => { console.log('error'); },
  {
    id: 'test'
  }
);
```

At this stage without the PR:
* Confirmed that the app crashes without the description

After, I applied the PR changes and:
* Confirmed that the app no longer crashes. The app name is now displayed.
* Added custom description and confirmed that the description displays instead of app name:

```js
PushNotification.createChannel(
  () => { console.log('success'); },
  () => { console.log('error'); },
  {
    id: 'test',
    description: 'Test',
  }
);
```

## Screenshots (if appropriate):

n/a

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
