### PR TITLE
doc(android): enable & set notification light with lightColor

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -277,6 +277,7 @@ A default channel with the id "PushPluginChannel" is created automatically. To m
 | `sound`                          | `String`  | The name of the sound file to be played upon receipt of the notification in this channel. Empty string to disable sound. Cannot be changed after channel is created.                                                                                               |
 | `vibration`                      | `Boolean` or `Array` | Boolean sets whether notification posted to this channel should vibrate. Array sets custom vibration pattern. Example - vibration: `[2000, 1000, 500, 500]`. Cannot be changed after channel is created.                 |
 | `visibility`                     | `Int`     | Sets whether notifications posted to this channel appear on the lockscreen or not, and if so, whether they appear in a redacted form. 0 = Private, 1 = Public, -1 = Secret.                                                         |
+| `lightColor`                     | `Int`     | Sets and enables the color of the notification light. The default value, `-1`, disables the notification light. (**Android Only**) |
 
 ## PushNotification.deleteChannel(successHandler, failureHandler, channelId)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Document missing API property, `lightColor`, which is used to enable and set the notification light for Android

## Related Issue

closes #16

## Motivation and Context

Keep documents up-to-date

## How Has This Been Tested?

n/a

## Screenshots (if appropriate):

## Types of changes

- [x] Documentation (non-breaking change which fixes an issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
