### PR TITLE
fix(android): Fatal Exception: java.lang.NullPointerException (PushPl…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@havesource/cordova-plugin-push",
-  "version": "2.0.0",
+  "version": "2.0.1-dev.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@havesource/cordova-plugin-push",
-  "version": "2.0.0",
+  "version": "2.0.1-dev.0",
   "description": "Register and receive push notifications.",
   "scripts": {
     "build": "babel src/js --out-dir www",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
   xmlns:android="http://schemas.android.com/apk/res/android"
-  id="@havesource/cordova-plugin-push" version="2.0.0">
+  id="@havesource/cordova-plugin-push" version="2.0.1-dev.0">
 
   <name>Cordova Push Plugin</name>
   <description>Enable receiving push notifications on Android, iOS and Windows devices. Android uses Firebase Cloud Messaging. iOS uses Apple APNS Notifications. Windows uses Microsoft WNS Notifications.</description>

--- a/src/android/com/adobe/phonegap/push/FCMService.java
+++ b/src/android/com/adobe/phonegap/push/FCMService.java
@@ -427,7 +427,15 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
       if (channelID != null) {
         mBuilder = new NotificationCompat.Builder(context, channelID);
       } else {
-        List<NotificationChannel> channels = mNotificationManager.getNotificationChannels();
+
+        List<NotificationChannel> channels = new ArrayList<>();
+
+        try {
+          channels = mNotificationManager.getNotificationChannels();
+        } catch (NullPointerException e) {
+          // Catch issue caused by "Attempt to invoke virtual method 'boolean android.app.NotificationChannel.isDeleted()' on a null object reference"
+          Log.e(LOG_TAG, "execute: Null Pointer Exception " + e.getMessage());
+        }
 
         if (channels.size() == 1) {
           channelID = channels.get(0).getId();

--- a/src/android/com/adobe/phonegap/push/PushPlugin.java
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.java
@@ -72,7 +72,16 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       final NotificationManager notificationManager = (NotificationManager) cordova.getActivity()
         .getSystemService(Context.NOTIFICATION_SERVICE);
-      List<NotificationChannel> notificationChannels = notificationManager.getNotificationChannels();
+
+      List<NotificationChannel> notificationChannels = new ArrayList<>();
+
+      try {
+        notificationChannels = notificationManager.getNotificationChannels();
+      } catch (NullPointerException e) {
+        // Catch issue caused by "Attempt to invoke virtual method 'boolean android.app.NotificationChannel.isDeleted()' on a null object reference"
+        Log.e(LOG_TAG, "execute: Null Pointer Exception " + e.getMessage());
+      }
+
       for (NotificationChannel notificationChannel : notificationChannels) {
         JSONObject channel = new JSONObject();
         channel.put(CHANNEL_ID, notificationChannel.getId());

--- a/src/android/com/adobe/phonegap/push/PushPlugin.java
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.java
@@ -166,7 +166,15 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       final NotificationManager notificationManager = (NotificationManager) cordova.getActivity()
         .getSystemService(Context.NOTIFICATION_SERVICE);
-      List<NotificationChannel> channels = notificationManager.getNotificationChannels();
+
+      List<NotificationChannel> channels = new ArrayList<>();
+
+      try {
+        channels = notificationManager.getNotificationChannels();
+      } catch (NullPointerException e) {
+        // Catch issue caused by "Attempt to invoke virtual method 'boolean android.app.NotificationChannel.isDeleted()' on a null object reference"
+        Log.e(LOG_TAG, "execute: Null Pointer Exception " + e.getMessage());
+      }
 
       for (int i = 0; i < channels.size(); i++) {
         id = channels.get(i).getId();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Crash fix that mainly affected Samsung devices with Android 8 and 9.

## Related Issue
https://github.com/phonegap/phonegap-plugin-push/issues/2709

## Motivation and Context
Some crashes produced by this error in the Firebase logs (0.5% of my users):
```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean android.app.NotificationChannel.isDeleted()' on a null object reference
       at android.os.Parcel.readException(Parcel.java:2035)
       at android.os.Parcel.readException(Parcel.java:1975)
       at android.app.INotificationManager$Stub$Proxy.getNotificationChannels(INotificationManager.java:1839)
       at android.app.NotificationManager.getNotificationChannels(NotificationManager.java:524)
       at com.adobe.phonegap.push.PushPlugin.createDefaultNotificationChannelIfNeeded(PushPlugin.java:169)
       at com.adobe.phonegap.push.PushPlugin.access$200(PushPlugin.java:40)
       at com.adobe.phonegap.push.PushPlugin$1.run(PushPlugin.java:215)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
       at java.lang.Thread.run(Thread.java:764)
```
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
I tested it in production for a couple of days and the error no longer appears in Firebase logs, 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![Captura de pantalla de 2021-04-30 12-06-01](https://user-images.githubusercontent.com/18549191/116680841-75c13f00-a9ac-11eb-92ac-83568328acb5.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

