### PR TITLE
feat(ios): increase firebase framework to 7.11.0

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -91,7 +91,7 @@
   </platform>
 
   <platform name="ios">
-    <preference name="IOS_FIREBASE_MESSAGING_VERSION" default="~> 6.32.2"/>
+    <preference name="IOS_FIREBASE_MESSAGING_VERSION" default="~> 7.11.0"/>
 
     <config-file target="config.xml" parent="/*">
       <feature name="PushNotification">

--- a/src/ios/PushPlugin.h
+++ b/src/ios/PushPlugin.h
@@ -69,7 +69,6 @@
 
 - (void)willSendDataMessageWithID:(NSString *)messageID error:(NSError *)error;
 - (void)didSendDataMessageWithID:(NSString *)messageID;
-- (void)didDeleteMessagesOnServer;
 
 // VoIP Features
 - (void)pushRegistry:(PKPushRegistry *)registry didUpdatePushCredentials:(PKPushCredentials *)credentials forType:(NSString *)type;

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -89,27 +89,12 @@
 #endif
 }
 
-// contains error info
-- (void)sendDataMessageFailure:(NSNotification *)notification {
-    NSLog(@"sendDataMessageFailure");
-}
-- (void)sendDataMessageSuccess:(NSNotification *)notification {
-    NSLog(@"sendDataMessageSuccess");
-}
-
 - (void)didSendDataMessageWithID:messageID {
     NSLog(@"didSendDataMessageWithID");
 }
 
 - (void)willSendDataMessageWithID:messageID error:error {
     NSLog(@"willSendDataMessageWithID");
-}
-
-- (void)didDeleteMessagesOnServer {
-    NSLog(@"didDeleteMessagesOnServer");
-    // Some messages sent to this device were deleted on the GCM server before reception, likely
-    // because the TTL expired. The client should notify the app server of this, so that the app
-    // server can resend those messages.
 }
 
 - (void)unregister:(CDVInvokedUrlCommand*)command;
@@ -180,18 +165,6 @@
         [[NSNotificationCenter defaultCenter]
          addObserver:self selector:@selector(onTokenRefresh)
          name:kFIRInstanceIDTokenRefreshNotification object:nil];
-
-        [[NSNotificationCenter defaultCenter]
-         addObserver:self selector:@selector(sendDataMessageFailure:)
-         name:FIRMessagingSendErrorNotification object:nil];
-
-        [[NSNotificationCenter defaultCenter]
-         addObserver:self selector:@selector(sendDataMessageSuccess:)
-         name:FIRMessagingSendSuccessNotification object:nil];
-
-        [[NSNotificationCenter defaultCenter]
-         addObserver:self selector:@selector(didDeleteMessagesOnServer)
-         name:FIRMessagingMessagesDeletedNotification object:nil];
 
         [self.commandDelegate runInBackground:^ {
             NSLog(@"Push Plugin register called");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Plugin cannot be installed in parallel with https://github.com/admob-plus/admob-plus or https://github.com/chemerisuk/cordova-plugin-firebase-analytics because of incompatible Firebase SDK versions.

## Related Issue
https://github.com/havesource/cordova-plugin-push/issues/84

## Motivation and Context
I use the plugin together with `admob-plus` and `cordova-plugin-firebase-analytics`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
cordova platform rm ios
cordova plugin add cordova-plugin-push
cordova platform add ios@6.2.0
cd platforms/ios
pod install
```
I have tested it on an iPhone 6s with iOS 14.5 and notifications are received without problems, except when the application is in the foreground, the event `push.on('notification', function(){});` does not fire, I don't know if this bug is due to the changes or it was already present in the plugin.

I'm not very familiar with `Objective-C` and the `Firebase SDK`, so I'm not sure if the removed identifiers would have to be replaced with something.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
