### PR TITLE
fix(android): java.lang.NullPointerException (PushHandlerActivity.java:28)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@havesource/cordova-plugin-push",
-  "version": "2.0.0",
+  "version": "2.0.1-dev.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@havesource/cordova-plugin-push",
-  "version": "2.0.0",
+  "version": "2.0.1-dev.0",
   "description": "Register and receive push notifications.",
   "scripts": {
     "build": "babel src/js --out-dir www",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
   xmlns:android="http://schemas.android.com/apk/res/android"
-  id="@havesource/cordova-plugin-push" version="2.0.0">
+  id="@havesource/cordova-plugin-push" version="2.0.1-dev.0">
 
   <name>Cordova Push Plugin</name>
   <description>Enable receiving push notifications on Android, iOS and Windows devices. Android uses Firebase Cloud Messaging. iOS uses Apple APNS Notifications. Windows uses Microsoft WNS Notifications.</description>

--- a/src/android/com/adobe/phonegap/push/BackgroundHandlerActivity.java
+++ b/src/android/com/adobe/phonegap/push/BackgroundHandlerActivity.java
@@ -24,15 +24,15 @@ public class BackgroundHandlerActivity extends Activity implements PushConstants
 
     Intent intent = getIntent();
 
-    int notId = intent.getExtras().getInt(NOT_ID, 0);
+    int notId = intent.getIntExtra(NOT_ID, 0);
     Log.d(LOG_TAG, "not id = " + notId);
     gcm.setNotification(notId, "");
     super.onCreate(savedInstanceState);
     Log.v(LOG_TAG, "onCreate");
-    String callback = getIntent().getExtras().getString("callback");
+    String callback = intent.getStringExtra(CALLBACK);
     Log.d(LOG_TAG, "callback = " + callback);
-    boolean startOnBackground = getIntent().getExtras().getBoolean(START_IN_BACKGROUND, false);
-    boolean dismissed = getIntent().getExtras().getBoolean(DISMISSED, false);
+    boolean startOnBackground = intent.getBooleanExtra(START_IN_BACKGROUND, false);
+    boolean dismissed = intent.getBooleanExtra(DISMISSED, false);
     Log.d(LOG_TAG, "dismissed = " + dismissed);
 
     if (!startOnBackground) {

--- a/src/android/com/adobe/phonegap/push/FCMService.java
+++ b/src/android/com/adobe/phonegap/push/FCMService.java
@@ -87,7 +87,7 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
       extras.putString(entry.getKey(), entry.getValue());
     }
 
-    if (extras != null && isAvailableSender(from)) {
+    if (extras != null && from != null && isAvailableSender(from)) {
       Context applicationContext = getApplicationContext();
 
       SharedPreferences prefs = applicationContext.getSharedPreferences(

--- a/src/android/com/adobe/phonegap/push/PushHandlerActivity.java
+++ b/src/android/com/adobe/phonegap/push/PushHandlerActivity.java
@@ -25,16 +25,16 @@ public class PushHandlerActivity extends Activity implements PushConstants {
 
     Intent intent = getIntent();
 
-    int notId = intent.getExtras().getInt(NOT_ID, 0);
+    int notId = intent.getIntExtra(NOT_ID, 0);
     Log.d(LOG_TAG, "not id = " + notId);
     gcm.setNotification(notId, "");
     super.onCreate(savedInstanceState);
     Log.v(LOG_TAG, "onCreate");
-    String callback = getIntent().getExtras().getString("callback");
+    String callback = intent.getStringExtra(CALLBACK);
     Log.d(LOG_TAG, "callback = " + callback);
-    boolean foreground = getIntent().getExtras().getBoolean("foreground", true);
-    boolean startOnBackground = getIntent().getExtras().getBoolean(START_IN_BACKGROUND, false);
-    boolean dismissed = getIntent().getExtras().getBoolean(DISMISSED, false);
+    boolean foreground = intent.getBooleanExtra(FOREGROUND, true);
+    boolean startOnBackground = intent.getBooleanExtra(START_IN_BACKGROUND, false);
+    boolean dismissed = intent.getBooleanExtra(DISMISSED, false);
     Log.d(LOG_TAG, "dismissed = " + dismissed);
 
     if (!startOnBackground) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Crash fix that mainly affected LG Nexus 5X with Android 8.1.

## Description
Changed `getExtras().getInt()` and similiars to `getIntExtra()` to avoid a `java.lang.NullPointerException` if `getExtras()` is null

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/phonegap/phonegap-plugin-push/issues/2903

## Motivation and Context
Some crashes produced by this error in the Firebase logs:

```
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'int android.os.Bundle.getInt(java.lang.String, int)' on a null object reference
       at com.adobe.phonegap.push.PushHandlerActivity.onCreate(PushHandlerActivity.java:28)
       at android.app.Activity.performCreate(Activity.java:7009)
       at android.app.Activity.performCreate(Activity.java:7000)
       at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1214)
       at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2731)
       at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2856)
       at android.app.ActivityThread.-wrap11()
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1589)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loop(Looper.java:164)
       at android.app.ActivityThread.main(ActivityThread.java:6494)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:438)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:807)
```
and
```
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'int android.os.Bundle.getInt(java.lang.String, int)' on a null object reference
       at com.adobe.phonegap.push.BackgroundHandlerActivity.onCreate(BackgroundHandlerActivity.java:27)
       at android.app.Activity.performCreate(Activity.java:7009)
       at android.app.Activity.performCreate(Activity.java:7000)
       at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1214)
       at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2731)
       at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2856)
       at android.app.ActivityThread.-wrap11()
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1589)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loop(Looper.java:164)
       at android.app.ActivityThread.main(ActivityThread.java:6494)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:438)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:807)
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested it in production for a couple of days and the error no longer appears in Firebase logs,

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
