### PR TITLE
feat(ios): update IOS_FIREBASE_MESSAGING_VERSION to > 8

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -91,7 +91,7 @@
   </platform>
 
   <platform name="ios">
-    <preference name="IOS_FIREBASE_MESSAGING_VERSION" default="~> 6.32.2"/>
+    <preference name="IOS_FIREBASE_MESSAGING_VERSION" default="~> 8.1.1"/>
 
     <config-file target="config.xml" parent="/*">
       <feature name="PushNotification">

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -31,7 +31,7 @@
 
 @import Firebase;
 @import FirebaseCore;
-@import FirebaseInstanceID;
+// @import FirebaseInstanceID;
 @import FirebaseMessaging;
 
 @implementation PushPlugin : CDVPlugin
@@ -55,15 +55,15 @@
 
 -(void)initRegistration;
 {
-    [[FIRInstanceID instanceID] instanceIDWithHandler:^(FIRInstanceIDResult * _Nullable result, NSError * _Nullable error) {
+    [[FIRMessaging messaging] tokenWithCompletion:^(NSString *token, NSError *error) {
         if (error != nil) {
-            NSLog(@"Error fetching remote instance ID: %@", error);
+            NSLog(@"Error getting FCM registration token: %@", error);
         } else {
-            NSLog(@"Remote instance ID (FCM Registration) Token: %@", result.token);
+            NSLog(@"FCM registration token: %@", token);
 
-            [self setFcmRegistrationToken: result.token];
+            [self setFcmRegistrationToken: token];
 
-            NSString* message = [NSString stringWithFormat:@"Remote InstanceID token: %@", result.token];
+            NSString* message = [NSString stringWithFormat:@"Remote InstanceID token: %@", token];
 
             id topics = [self fcmTopics];
             if (topics != nil) {
@@ -74,9 +74,31 @@
                 }
             }
 
-            [self registerWithToken:result.token];
+            [self registerWithToken: token];
         }
     }];
+    // [[FIRInstanceID instanceID] instanceIDWithHandler:^(FIRInstanceIDResult * _Nullable result, NSError * _Nullable error) {
+    //     if (error != nil) {
+    //         NSLog(@"Error fetching remote instance ID: %@", error);
+    //     } else {
+    //         NSLog(@"Remote instance ID (FCM Registration) Token: %@", result.token);
+
+    //         [self setFcmRegistrationToken: result.token];
+
+    //         NSString* message = [NSString stringWithFormat:@"Remote InstanceID token: %@", result.token];
+
+    //         id topics = [self fcmTopics];
+    //         if (topics != nil) {
+    //             for (NSString *topic in topics) {
+    //                 NSLog(@"subscribe to topic: %@", topic);
+    //                 id pubSub = [FIRMessaging messaging];
+    //                 [pubSub subscribeToTopic:topic];
+    //             }
+    //         }
+
+    //         [self registerWithToken:result.token];
+    //     }
+    // }];
 }
 
 //  FCM refresh token
@@ -177,21 +199,21 @@
         }];
     } else {
         NSLog(@"Push Plugin VoIP missing or false");
-        [[NSNotificationCenter defaultCenter]
-         addObserver:self selector:@selector(onTokenRefresh)
-         name:kFIRInstanceIDTokenRefreshNotification object:nil];
+        // [[NSNotificationCenter defaultCenter]
+        //  addObserver:self selector:@selector(onTokenRefresh)
+        //  name:kFIRInstanceIDTokenRefreshNotification object:nil];
 
-        [[NSNotificationCenter defaultCenter]
-         addObserver:self selector:@selector(sendDataMessageFailure:)
-         name:FIRMessagingSendErrorNotification object:nil];
+        // [[NSNotificationCenter defaultCenter]
+        //  addObserver:self selector:@selector(sendDataMessageFailure:)
+        //  name:FIRMessagingSendErrorNotification object:nil];
 
-        [[NSNotificationCenter defaultCenter]
-         addObserver:self selector:@selector(sendDataMessageSuccess:)
-         name:FIRMessagingSendSuccessNotification object:nil];
+        // [[NSNotificationCenter defaultCenter]
+        //  addObserver:self selector:@selector(sendDataMessageSuccess:)
+        //  name:FIRMessagingSendSuccessNotification object:nil];
 
-        [[NSNotificationCenter defaultCenter]
-         addObserver:self selector:@selector(didDeleteMessagesOnServer)
-         name:FIRMessagingMessagesDeletedNotification object:nil];
+        // [[NSNotificationCenter defaultCenter]
+        //  addObserver:self selector:@selector(didDeleteMessagesOnServer)
+        //  name:FIRMessagingMessagesDeletedNotification object:nil];
 
         [self.commandDelegate runInBackground:^ {
             NSLog(@"Push Plugin register called");


### PR DESCRIPTION
This allows building with xcode 12

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
To get building with xcode 12 working and make it work with other dependencies I updated the messaging version.

I left some commented code since I wasn't super sure this would work. But I can remove that if you want to merge.

I migrated `initRegistration` according to https://firebase.google.com/docs/projects/manage-installations#fid-iid but since I tested APN I can't say it's 100% correct.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/havesource/cordova-plugin-push/issues/84

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested this and notifications on iOS still work. 
Note that I tested this with APN and not FCM so the migrated `initRegistration` might not be super correct.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
