### PR TITLE
docs(typescript): update TS type import to new package name

### DIFF
--- a/docs/TYPESCRIPT.md
+++ b/docs/TYPESCRIPT.md
@@ -8,7 +8,7 @@ All objects will be understood as having a defined type, including init options 
 All available attributes and properties will have autocomplete support and type checkings.
 
 ```typescript
-import 'phonegap-plugin-push/types';
+import '@havesource/cordova-plugin-push/types';
 
 const push = PushNotification.init({
 	android: {


### PR DESCRIPTION
## Description
Update the `import` in the Typescript docs to use the new `@havesource/cordova-plugin-push` package name.

## Related Issue
n/a, just a small docs fix

## Motivation and Context
When using the docs as-is, people will use the types from the previous package, which could even cause issues as that probably won't be installed.

## How Has This Been Tested?
Successfully used that new import in my own project.

## Screenshots (if appropriate):
n/a

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
