### PR TITLE
Bump GradlePluginGoogleServicesVersion to 4.3.8

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -59,7 +59,7 @@
 
     <config-file target="config.xml" parent="/*">
       <preference name="GradlePluginGoogleServicesEnabled" value="true" />
-      <preference name="GradlePluginGoogleServicesVersion" value="4.2.0" />
+      <preference name="GradlePluginGoogleServicesVersion" value="4.3.8" />
     </config-file>
 
     <preference name="ANDROID_SUPPORT_V13_VERSION" default="28.0.0"/>


### PR DESCRIPTION
## Description
This is needed for cordova-android 10.0.0 support. As previous version '4.2.0' did not support gradle 7.0.

## Related Issue
#108

## How Has This Been Tested?
I made a build using this version and tested notifications. Which worked correctly


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
