### PR TITLE
added android:exported=true in service tag as in Android 11 its compu…

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -46,13 +46,13 @@
       <receiver android:name="com.adobe.phonegap.push.BackgroundActionButtonHandler"/>
       <receiver android:name="com.adobe.phonegap.push.PushDismissedHandler"/>
 
-      <service android:name="com.adobe.phonegap.push.FCMService">
+      <service android:exported="true" android:name="com.adobe.phonegap.push.FCMService">
         <intent-filter>
           <action android:name="com.google.firebase.MESSAGING_EVENT"/>
         </intent-filter>
       </service>
 
-      <service android:name="com.adobe.phonegap.push.PushInstanceIDListenerService">
+      <service android:exported="true" android:name="com.adobe.phonegap.push.PushInstanceIDListenerService">
         <intent-filter>
           <action android:name="com.google.firebase.INSTANCE_ID_EVENT"/>
         </intent-filter>

--- a/src/android/com/adobe/phonegap/push/FCMService.kt
+++ b/src/android/com/adobe/phonegap/push/FCMService.kt
@@ -600,7 +600,7 @@ class FCMService : FirebaseMessagingService() {
         NotificationCompat.Builder(context, channelID)
       }
     } else {
-      return NotificationCompat.Builder(context)
+      return NotificationCompat.Builder(context, "channel_id")
     }
   }
 
@@ -1163,7 +1163,7 @@ class FCMService : FirebaseMessagingService() {
   }
 
   private fun fromHtml(source: String?): Spanned? {
-    return if (source != null) Html.fromHtml(source) else null
+    return if (source != null) HtmlCompat.fromHtml(source, HtmlCompat.FROM_HTML_MODE_LEGACY) else null;
   }
 
   private fun isAvailableSender(from: String?): Boolean {

--- a/src/android/com/adobe/phonegap/push/FCMService.kt
+++ b/src/android/com/adobe/phonegap/push/FCMService.kt
@@ -34,6 +34,7 @@ import java.net.URL
 import java.security.SecureRandom
 import java.util.*
 import androidx.core.text.HtmlCompat
+import androidx.core.app.NotificationCompat.WearableExtender;
 
 /**
  * Firebase Cloud Messaging Service Class

--- a/src/android/com/adobe/phonegap/push/FCMService.kt
+++ b/src/android/com/adobe/phonegap/push/FCMService.kt
@@ -28,7 +28,7 @@ import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 import java.io.IOException
-import java.lang.java.lang.NullPointerException
+import java.lang.NullPointerException
 import java.io.InputStream
 import java.net.HttpURLConnection
 import java.net.URL
@@ -576,7 +576,7 @@ class FCMService : FirebaseMessagingService() {
     createActions(extras, mBuilder, notId)
     mNotificationManager.notify(appName, notId, mBuilder.build())
     } catch (e: NullPointerException) {
-    Log.e(TAG, "execute: Null Pointer Exception", e.localizedMessage);
+    Log.e(TAG, "execute: Null Pointer Exception");
     }
   }
 

--- a/src/android/com/adobe/phonegap/push/FCMService.kt
+++ b/src/android/com/adobe/phonegap/push/FCMService.kt
@@ -28,7 +28,7 @@ import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 import java.io.IOException
-import java.io.NullPointerException
+import java.lang.java.lang.NullPointerException
 import java.io.InputStream
 import java.net.HttpURLConnection
 import java.net.URL
@@ -575,8 +575,8 @@ class FCMService : FirebaseMessagingService() {
      */
     createActions(extras, mBuilder, notId)
     mNotificationManager.notify(appName, notId, mBuilder.build())
-    } catch (NullPointerException e) {
-    Log.e(TAG, "execute: Null Pointer Exception " + e.getMessage());
+    } catch (e: NullPointerException) {
+    Log.e(TAG, "execute: Null Pointer Exception", e.localizedMessage);
     }
   }
 

--- a/src/android/com/adobe/phonegap/push/FCMService.kt
+++ b/src/android/com/adobe/phonegap/push/FCMService.kt
@@ -436,6 +436,7 @@ class FCMService : FirebaseMessagingService() {
   }
 
   private fun createNotification(extras: Bundle?) {
+  try {
     val mNotificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
     val appName = getAppName(this)
     val notId = parseNotificationIdToInt(extras)
@@ -573,6 +574,9 @@ class FCMService : FirebaseMessagingService() {
      */
     createActions(extras, mBuilder, notId)
     mNotificationManager.notify(appName, notId, mBuilder.build())
+    } catch (NullPointerException e) {
+    Log.e(TAG, "execute: Null Pointer Exception " + e.getMessage());
+    }
   }
 
   private fun createNotificationBuilder(

--- a/src/android/com/adobe/phonegap/push/FCMService.kt
+++ b/src/android/com/adobe/phonegap/push/FCMService.kt
@@ -28,6 +28,7 @@ import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 import java.io.IOException
+import java.io.NullPointerException
 import java.io.InputStream
 import java.net.HttpURLConnection
 import java.net.URL

--- a/src/android/com/adobe/phonegap/push/FCMService.kt
+++ b/src/android/com/adobe/phonegap/push/FCMService.kt
@@ -35,7 +35,7 @@ import java.net.URL
 import java.security.SecureRandom
 import java.util.*
 import androidx.core.text.HtmlCompat
-import androidx.core.app.NotificationCompat.WearableExtender;
+import androidx.core.app.NotificationCompat.WearableExtender
 
 /**
  * Firebase Cloud Messaging Service Class
@@ -576,7 +576,7 @@ class FCMService : FirebaseMessagingService() {
     createActions(extras, mBuilder, notId)
     mNotificationManager.notify(appName, notId, mBuilder.build())
     } catch (e: NullPointerException) {
-    Log.e(TAG, "execute: Null Pointer Exception");
+    Log.e(TAG, "execute: Null Pointer Exception in getchannels");
     }
   }
 

--- a/src/android/com/adobe/phonegap/push/FCMService.kt
+++ b/src/android/com/adobe/phonegap/push/FCMService.kt
@@ -33,6 +33,7 @@ import java.net.HttpURLConnection
 import java.net.URL
 import java.security.SecureRandom
 import java.util.*
+import androidx.core.text.HtmlCompat
 
 /**
  * Firebase Cloud Messaging Service Class

--- a/src/android/com/adobe/phonegap/push/PushInstanceIDListenerService.kt
+++ b/src/android/com/adobe/phonegap/push/PushInstanceIDListenerService.kt
@@ -4,6 +4,8 @@ import android.annotation.SuppressLint
 import android.util.Log
 import com.google.firebase.iid.FirebaseInstanceId
 import com.google.firebase.messaging.FirebaseMessagingService
+import java.lang.NullPointerException
+
 
 /**
  * Push InstanceID Listener Service
@@ -21,6 +23,7 @@ class PushInstanceIDListenerService : FirebaseMessagingService() {
    * @param token
    */
   override fun onNewToken(token: String) {
+  try {
     super.onNewToken(token)
     FirebaseInstanceId.getInstance().instanceId
       .addOnSuccessListener { instanceIdResult ->
@@ -30,6 +33,9 @@ class PushInstanceIDListenerService : FirebaseMessagingService() {
 
         // TODO: Implement this method to send any registration to your app's servers.
         //sendRegistrationToServer(refreshedToken);
+      }
+      } catch (e: NullPointerException) {
+      Log.e(TAG, "execute: Null Pointer Exception in pushplugin initialize");
       }
   }
 }

--- a/src/android/com/adobe/phonegap/push/PushPlugin.kt
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.kt
@@ -25,7 +25,6 @@ import org.json.JSONException
 import org.json.JSONObject
 import java.io.IOException
 import java.util.*
-import com.google.firebase.installations.FirebaseInstallations
 
 /**
  * Cordova Plugin Push

--- a/src/android/com/adobe/phonegap/push/PushPlugin.kt
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.kt
@@ -28,6 +28,7 @@ import java.util.*
 import com.google.firebase.iid.InstanceIdResult;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
+import com.google.firebase.FirebaseApp
 
 /**
  * Cordova Plugin Push

--- a/src/android/com/adobe/phonegap/push/PushPlugin.kt
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.kt
@@ -25,6 +25,9 @@ import org.json.JSONException
 import org.json.JSONObject
 import java.io.IOException
 import java.util.*
+import com.google.firebase.iid.InstanceIdResult;
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.Task;
 
 /**
  * Cordova Plugin Push
@@ -462,7 +465,25 @@ class PushPlugin : CordovaPlugin() {
         Log.v(TAG, formatLogMessage("senderID=$senderID"))
 
         try {
-           token = FirebaseInstanceId.getInstance().token
+           // token = FirebaseInstanceId.getInstance().token
+           FirebaseInstanceId.getInstance().getInstanceId()
+                                   .addOnCompleteListener(new OnCompleteListener<InstanceIdResult>() {
+                   @Override
+                   public void onComplete(@NonNull Task<InstanceIdResult> task) {
+                       if (!task.isSuccessful()) {
+                           Log.w(TAG, "getInstanceId failed", task.getException());
+                           return;
+                       }
+
+                       // Get new Instance ID token
+                        token = task.getResult().getToken();
+
+                       // Log and toast
+                     //  String msg = getString(R.string.msg_token_fmt, token);
+                       Log.d(TAG, msg);
+                    //   Toast.makeText(MainActivity.this, msg, Toast.LENGTH_SHORT).show();
+                   }
+               });
         } catch (e: IllegalStateException) {
           Log.e(TAG, formatLogMessage("Firebase Token Exception ${e.message}"))
         }

--- a/src/android/com/adobe/phonegap/push/PushPlugin.kt
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.kt
@@ -469,6 +469,22 @@ class PushPlugin : CordovaPlugin() {
 
         try {
            // token = FirebaseInstanceId.getInstance().token
+           FirebaseApp.getInstance()
+            FirebaseInstanceId.getInstance().instanceId.addOnCompleteListener { task ->
+                if(task.isSuccessful){
+                    val result = task.result
+                    if (result != null) {
+                        // Get new Instance ID token
+                         token = result.token
+                    } else {
+                        token = null
+                        Log.d("token", "Could not retrieve token")
+                    }
+                } else {
+                    token = null
+                    Log.d("token", "Could not retrieve token")
+                }
+            }
 
         } catch (e: IllegalStateException) {
           Log.e(TAG, formatLogMessage("Firebase Token Exception ${e.message}"))

--- a/src/android/com/adobe/phonegap/push/PushPlugin.kt
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.kt
@@ -25,10 +25,12 @@ import org.json.JSONException
 import org.json.JSONObject
 import java.io.IOException
 import java.util.*
-import com.google.firebase.iid.InstanceIdResult;
-import com.google.android.gms.tasks.OnCompleteListener;
-import com.google.android.gms.tasks.Task;
+import com.google.firebase.iid.InstanceIdResult
+import com.google.android.gms.tasks.OnCompleteListener
+import com.google.android.gms.tasks.Task
 import com.google.firebase.FirebaseApp
+import java.lang.NullPointerException
+
 
 /**
  * Cordova Plugin Push
@@ -788,8 +790,12 @@ class PushPlugin : CordovaPlugin() {
    * Initialize
    */
   override fun initialize(cordova: CordovaInterface, webView: CordovaWebView) {
+  try {
     super.initialize(cordova, webView)
     isInForeground = true
+    } catch (e: NullPointerException) {
+        Log.e(TAG, "execute: Null Pointer Exception in pushplugin initialize");
+    }
   }
 
   /**

--- a/src/android/com/adobe/phonegap/push/PushPlugin.kt
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.kt
@@ -467,22 +467,7 @@ class PushPlugin : CordovaPlugin() {
 
         try {
            // token = FirebaseInstanceId.getInstance().token
-           FirebaseApp.getInstance()
-                   FirebaseInstanceId.getInstance().instanceId.addOnCompleteListener { task ->
-                       if(task.isSuccessful){
-                           val result = task.result
-                           if (result != null) {
-                               // Get new Instance ID token
-                                token = result.token
-                           } else {
-                               token = null
-                               Log.d("token", "Could not retrieve token")
-                           }
-                       } else {
-                           token = null
-                           Log.d("token", "Could not retrieve token")
-                       }
-                   }
+
         } catch (e: IllegalStateException) {
           Log.e(TAG, formatLogMessage("Firebase Token Exception ${e.message}"))
         }

--- a/src/android/com/adobe/phonegap/push/PushPlugin.kt
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.kt
@@ -463,16 +463,7 @@ class PushPlugin : CordovaPlugin() {
         Log.v(TAG, formatLogMessage("senderID=$senderID"))
 
         try {
-        FirebaseInstallations.getInstance().getToken(/* forceRefresh */ true)
-            .addOnCompleteListener { task ->
-                if (task.isSuccessful) {
-                    token = task.result?.token
-                    Log.d("Installations", "Installation auth token: " + task.result?.token)
-                } else {
-                    Log.e("Installations", "Unable to get Installation auth token")
-                }
-            }
-          // token = FirebaseMessaging.getInstance().getToken();
+           token = FirebaseInstanceId.getInstance().token
         } catch (e: IllegalStateException) {
           Log.e(TAG, formatLogMessage("Firebase Token Exception ${e.message}"))
         }

--- a/src/android/com/adobe/phonegap/push/PushPlugin.kt
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.kt
@@ -473,7 +473,7 @@ class PushPlugin : CordovaPlugin() {
                            val result = task.result
                            if (result != null) {
                                // Get new Instance ID token
-                                token = result!!.token
+                                token = result.token
                            } else {
                                token = null
                                Log.d("token", "Could not retrieve token")

--- a/src/android/com/adobe/phonegap/push/PushPlugin.kt
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.kt
@@ -462,7 +462,12 @@ class PushPlugin : CordovaPlugin() {
         Log.v(TAG, formatLogMessage("senderID=$senderID"))
 
         try {
-          token = FirebaseInstanceId.getInstance().token
+          FirebaseMessaging.getInstance().token.addOnSuccessListener {
+            if(result != null) {
+              token = result
+              // DO your thing with your firebase token
+            }
+          }
         } catch (e: IllegalStateException) {
           Log.e(TAG, formatLogMessage("Firebase Token Exception ${e.message}"))
         }

--- a/src/android/com/adobe/phonegap/push/PushPlugin.kt
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.kt
@@ -462,12 +462,7 @@ class PushPlugin : CordovaPlugin() {
         Log.v(TAG, formatLogMessage("senderID=$senderID"))
 
         try {
-          FirebaseMessaging.getInstance().token.addOnSuccessListener {
-            if(result != null) {
-              token = result
-              // DO your thing with your firebase token
-            }
-          }
+          token = FirebaseMessaging.getToken();
         } catch (e: IllegalStateException) {
           Log.e(TAG, formatLogMessage("Firebase Token Exception ${e.message}"))
         }

--- a/src/android/com/adobe/phonegap/push/PushPlugin.kt
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.kt
@@ -466,24 +466,22 @@ class PushPlugin : CordovaPlugin() {
 
         try {
            // token = FirebaseInstanceId.getInstance().token
-           FirebaseInstanceId.getInstance().getInstanceId()
-                                   .addOnCompleteListener(new OnCompleteListener<InstanceIdResult>() {
-                   @Override
-                   public void onComplete(@NonNull Task<InstanceIdResult> task) {
-                       if (!task.isSuccessful()) {
-                           Log.w(TAG, "getInstanceId failed", task.getException());
-                           return;
+           FirebaseApp.getInstance()
+                   FirebaseInstanceId.getInstance().instanceId.addOnCompleteListener { task ->
+                       if(task.isSuccessful){
+                           val result = task.result
+                           if (result != null) {
+                               // Get new Instance ID token
+                                token = result!!.token
+                           } else {
+                               token = null
+                               Log.d("token", "Could not retrieve token")
+                           }
+                       } else {
+                           token = null
+                           Log.d("token", "Could not retrieve token")
                        }
-
-                       // Get new Instance ID token
-                        token = task.getResult().getToken();
-
-                       // Log and toast
-                     //  String msg = getString(R.string.msg_token_fmt, token);
-                       Log.d(TAG, msg);
-                    //   Toast.makeText(MainActivity.this, msg, Toast.LENGTH_SHORT).show();
                    }
-               });
         } catch (e: IllegalStateException) {
           Log.e(TAG, formatLogMessage("Firebase Token Exception ${e.message}"))
         }

--- a/src/android/com/adobe/phonegap/push/PushPlugin.kt
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.kt
@@ -462,7 +462,7 @@ class PushPlugin : CordovaPlugin() {
         Log.v(TAG, formatLogMessage("senderID=$senderID"))
 
         try {
-          token = FirebaseMessaging.getToken();
+          token = FirebaseMessaging.getInstance().getToken();
         } catch (e: IllegalStateException) {
           Log.e(TAG, formatLogMessage("Firebase Token Exception ${e.message}"))
         }

--- a/src/android/com/adobe/phonegap/push/PushPlugin.kt
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.kt
@@ -25,6 +25,7 @@ import org.json.JSONException
 import org.json.JSONObject
 import java.io.IOException
 import java.util.*
+import com.google.firebase.installations.FirebaseInstallations
 
 /**
  * Cordova Plugin Push
@@ -462,7 +463,16 @@ class PushPlugin : CordovaPlugin() {
         Log.v(TAG, formatLogMessage("senderID=$senderID"))
 
         try {
-          token = FirebaseMessaging.getInstance().getToken();
+        FirebaseInstallations.getInstance().getToken(/* forceRefresh */ true)
+            .addOnCompleteListener { task ->
+                if (task.isSuccessful) {
+                    token = task.result?.token
+                    Log.d("Installations", "Installation auth token: " + task.result?.token)
+                } else {
+                    Log.e("Installations", "Unable to get Installation auth token")
+                }
+            }
+          // token = FirebaseMessaging.getInstance().getToken();
         } catch (e: IllegalStateException) {
           Log.e(TAG, formatLogMessage("Firebase Token Exception ${e.message}"))
         }


### PR DESCRIPTION
…lsory to have this tag if intent-filter is used

<!--- Provide a general summary of your changes in the Title above -->

## Description
We need to have android:exported="true" tag in services also if we are using intent-filter. This is required in Android 11 + builds.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
