### PR TITLE
doc: add 2.x and 3.x to PLATFORM_SUPPORT.md

### DIFF
--- a/docs/PLATFORM_SUPPORT.md
+++ b/docs/PLATFORM_SUPPORT.md
@@ -1,5 +1,21 @@
 ## Supported Platforms
 
+### Version 3.x.x
+
+- Cordova CLI (10.0.0 or newer)
+- Android (`cordova-android` 9.0.0 or higher)
+- Browser
+- iOS (`cordova-ios` 6.0.0 or higher)
+- Windows Universal (not Windows Phone 8)
+
+### Version 2.x.x
+
+- Cordova CLI (7.1.0 or newer)
+- Android (`cordova-android` 7.1.0 or higher)
+- Browser
+- iOS (`cordova-ios` 4.5.0 or higher)
+- Windows Universal (not Windows Phone 8)
+
 ### Version 1.9.x
 
 - Cordova CLI (6.4.0 or newer)


### PR DESCRIPTION
## Description
Update PLATFORM_SUPPORT.md to mention the supported cordova and platform versions for the 2.x and 3.x versions of the plugin.

The mentioned versions are based on the information in the `<engines>` tag in `plugin.xml` for versions `2.3.0` and `3.0.0`.

## Related Issue
n/a, just a minor docs change.

## Motivation and Context
The previous information was out of date.

## How Has This Been Tested?
n/a, just a docs change

## Screenshots (if appropriate):
n/a

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
