### PR TITLE
chore: correct Bower metadata to MIT license

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "authors": [
     "Adobe PhoneGap Team"
   ],
-  "license": "APL",
+  "license": "MIT",
   "keywords": [
     "ecosystem:cordova",
     "ecosystem:phonegap",


### PR DESCRIPTION
The `bower.json` file contains a false license attribute. This change had already been fixed in `package.json` in 2017 in commit 4274d0759acd7110ed2592ed1d2ce3bf692711d3

closes #165

Signed-off-by: Nico Rikken <nico.rikken@alliander.com>