### PR TITLE
#87 Claim activity permissions

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -32,6 +32,8 @@
       <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
       <uses-permission android:name="android.permission.WAKE_LOCK"/>
       <uses-permission android:name="android.permission.VIBRATE"/>
+      <permission android:name="${applicationId}.permission.PushHandlerActivity" android:protectionLevel="signature"></permission>
+      <permission android:name="${applicationId}.permission.BackgroundHandlerActivity" android:protectionLevel="signature"></permission>
     </config-file>
 
     <config-file target="AndroidManifest.xml" parent="/manifest/application">


### PR DESCRIPTION
As mentioned in #87, there is an issue with the way activities are declared that allows them to be launched by other applications. This was previously solved in https://github.com/phonegap/phonegap-plugin-push/pull/1362, but it seems like a later commit https://github.com/phonegap/phonegap-plugin-push/commit/4bbc8185efb972d93cea6d7bac09ec8c9e25b06e introduced a regression and it hasn't been fixed since.