### PR TITLE
Add full screen activity

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -32,9 +32,11 @@
       <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
       <uses-permission android:name="android.permission.WAKE_LOCK"/>
       <uses-permission android:name="android.permission.VIBRATE"/>
+      <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
     </config-file>
 
     <config-file target="AndroidManifest.xml" parent="/manifest/application">
+      <activity android:name="com.adobe.phonegap.push.FullScreenActivity" android:showOnLockScreen="true" android:turnScreenOn="true" android:theme="@android:style/Theme.DeviceDefault.NoActionBar"/>
       <activity android:name="com.adobe.phonegap.push.PushHandlerActivity" android:exported="true" android:permission="${applicationId}.permission.PushHandlerActivity"/>
       <activity android:name="com.adobe.phonegap.push.BackgroundHandlerActivity" android:exported="true" android:permission="${applicationId}.permission.BackgroundHandlerActivity">
         <intent-filter>
@@ -75,8 +77,9 @@
     <framework src="me.leolin:ShortcutBadger:1.1.22@aar"/>
     <framework src="com.google.firebase:firebase-messaging:$FCM_VERSION"/>
 
-    <source-file src="src/android/com/adobe/phonegap/push/FCMService.kt" target-dir="java/com/adobe/phonegap/push/"/>
     <source-file src="src/android/com/adobe/phonegap/push/PushConstants.kt" target-dir="java/com/adobe/phonegap/push/"/>
+    <source-file src="src/android/com/adobe/phonegap/push/FullScreenActivity.kt" target-dir="java/com/adobe/phonegap/push/"/>
+    <source-file src="src/android/com/adobe/phonegap/push/FCMService.kt" target-dir="java/com/adobe/phonegap/push/"/>
     <source-file src="src/android/com/adobe/phonegap/push/PushHandlerActivity.kt" target-dir="java/com/adobe/phonegap/push/"/>
     <source-file src="src/android/com/adobe/phonegap/push/BackgroundHandlerActivity.kt" target-dir="java/com/adobe/phonegap/push/"/>
     <source-file src="src/android/com/adobe/phonegap/push/PushInstanceIDListenerService.kt" target-dir="java/com/adobe/phonegap/push/"/>

--- a/src/android/com/adobe/phonegap/push/FCMService.kt
+++ b/src/android/com/adobe/phonegap/push/FCMService.kt
@@ -668,11 +668,6 @@ class FCMService : FirebaseMessagingService() {
           var intent: Intent?
           var pIntent: PendingIntent?
           val callback = action.getString(PushConstants.CALLBACK)
-          val updateActivityFlag = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
-          } else {
-            PendingIntent.FLAG_UPDATE_CURRENT
-          }
           when {
             inline -> {
               Log.d(TAG, "Version: ${Build.VERSION.SDK_INT} = ${Build.VERSION_CODES.M}")
@@ -769,10 +764,8 @@ class FCMService : FirebaseMessagingService() {
         mBuilder.extend(NotificationCompat.WearableExtender().addActions(wActions))
         wActions.clear()
       } catch (e: JSONException) {
-          Log.d(TAG, "Create actions error: ${e.message}")
+        // nope
       }
-    } else {
-        Log.d(TAG, "No action to perform")
     }
   }
 

--- a/src/android/com/adobe/phonegap/push/FCMService.kt
+++ b/src/android/com/adobe/phonegap/push/FCMService.kt
@@ -1,6 +1,7 @@
 package com.adobe.phonegap.push
 
 import android.annotation.SuppressLint
+import android.app.Activity
 import android.app.Notification
 import android.app.NotificationManager
 import android.app.PendingIntent
@@ -436,19 +437,22 @@ class FCMService : FirebaseMessagingService() {
   private fun createNotification(extras: Bundle?) {
     val mNotificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
     val appName = getAppName(this)
+    val fullScreenIntent: Boolean = extras?.getString(PushConstants.FULL_SCREEN_NOTIFICATION, "").equals("1")
+    Log.d(TAG, "fullScreenIntent = $fullScreenIntent")
     val notId = parseNotificationIdToInt(extras)
-    val notificationIntent = Intent(this, PushHandlerActivity::class.java).apply {
-      addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
-      putExtra(PushConstants.PUSH_BUNDLE, extras)
-      putExtra(PushConstants.NOT_ID, notId)
-    }
+    val activityClass: Class<out Activity?> =
+      if (fullScreenIntent) FullScreenActivity::class.java else PushHandlerActivity::class.java
+    val notificationIntent = Intent(this, activityClass)
+    notificationIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+    notificationIntent.putExtra(PushConstants.PUSH_BUNDLE, extras)
+    notificationIntent.putExtra(PushConstants.NOT_ID, notId)
     val random = SecureRandom()
     var requestCode = random.nextInt()
     val contentIntent = PendingIntent.getActivity(
       this,
       requestCode,
       notificationIntent,
-      PendingIntent.FLAG_UPDATE_CURRENT
+      PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
     )
     val dismissedNotificationIntent = Intent(
       this,
@@ -467,7 +471,7 @@ class FCMService : FirebaseMessagingService() {
       this,
       requestCode,
       dismissedNotificationIntent,
-      PendingIntent.FLAG_CANCEL_CURRENT
+      PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_MUTABLE
     )
 
     val mBuilder: NotificationCompat.Builder =
@@ -479,7 +483,17 @@ class FCMService : FirebaseMessagingService() {
       .setContentIntent(contentIntent)
       .setDeleteIntent(deleteIntent)
       .setAutoCancel(true)
-
+    if (fullScreenIntent) {
+      mBuilder
+        .setFullScreenIntent(contentIntent, true)
+        .setPriority(NotificationCompat.PRIORITY_HIGH)
+    } else {
+      mBuilder.setContentIntent(contentIntent)
+    }
+    val prefs: SharedPreferences = context.getSharedPreferences(
+      PushConstants.COM_ADOBE_PHONEGAP_PUSH,
+      Context.MODE_PRIVATE
+    )
     val localIcon = pushSharedPref.getString(PushConstants.ICON, null)
     val localIconColor = pushSharedPref.getString(PushConstants.ICON_COLOR, null)
     val soundOption = pushSharedPref.getBoolean(PushConstants.SOUND, true)
@@ -654,7 +668,11 @@ class FCMService : FirebaseMessagingService() {
           var intent: Intent?
           var pIntent: PendingIntent?
           val callback = action.getString(PushConstants.CALLBACK)
-
+          val updateActivityFlag = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+          } else {
+            PendingIntent.FLAG_UPDATE_CURRENT
+          }
           when {
             inline -> {
               Log.d(TAG, "Version: ${Build.VERSION.SDK_INT} = ${Build.VERSION_CODES.M}")
@@ -672,11 +690,12 @@ class FCMService : FirebaseMessagingService() {
               pIntent = if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.M) {
                 Log.d(TAG, "push activity for notId $notId")
 
+
                 PendingIntent.getActivity(
                   this,
                   uniquePendingIntentRequestCode,
                   intent,
-                  PendingIntent.FLAG_ONE_SHOT
+                  oneShotActivityFlagPendingIntent.FLAG_ONE_SHOT or PendingIntent.FLAG_MUTABLE
                 )
               } else {
                 Log.d(TAG, "push receiver for notId $notId")
@@ -685,7 +704,7 @@ class FCMService : FirebaseMessagingService() {
                   this,
                   uniquePendingIntentRequestCode,
                   intent,
-                  PendingIntent.FLAG_ONE_SHOT
+                  PendingIntent.FLAG_ONE_SHOT or PendingIntent.FLAG_MUTABLE
                 )
               }
             }
@@ -696,7 +715,7 @@ class FCMService : FirebaseMessagingService() {
               pIntent = PendingIntent.getActivity(
                 this, uniquePendingIntentRequestCode,
                 intent,
-                PendingIntent.FLAG_UPDATE_CURRENT
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
               )
             }
 
@@ -706,7 +725,7 @@ class FCMService : FirebaseMessagingService() {
               pIntent = PendingIntent.getBroadcast(
                 this, uniquePendingIntentRequestCode,
                 intent,
-                PendingIntent.FLAG_UPDATE_CURRENT
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
               )
             }
           }
@@ -750,8 +769,10 @@ class FCMService : FirebaseMessagingService() {
         mBuilder.extend(NotificationCompat.WearableExtender().addActions(wActions))
         wActions.clear()
       } catch (e: JSONException) {
-        // nope
+          Log.d(TAG, "Create actions error: ${e.message}")
       }
+    } else {
+        Log.d(TAG, "No action to perform")
     }
   }
 

--- a/src/android/com/adobe/phonegap/push/FCMService.kt
+++ b/src/android/com/adobe/phonegap/push/FCMService.kt
@@ -690,7 +690,7 @@ class FCMService : FirebaseMessagingService() {
                   this,
                   uniquePendingIntentRequestCode,
                   intent,
-                  oneShotActivityFlagPendingIntent.FLAG_ONE_SHOT or PendingIntent.FLAG_MUTABLE
+                  PendingIntent.FLAG_ONE_SHOT or PendingIntent.FLAG_MUTABLE
                 )
               } else {
                 Log.d(TAG, "push receiver for notId $notId")

--- a/src/android/com/adobe/phonegap/push/FullScreenActivity.kt
+++ b/src/android/com/adobe/phonegap/push/FullScreenActivity.kt
@@ -1,0 +1,85 @@
+package com.adobe.phonegap.push
+
+import android.app.Activity
+import android.app.KeyguardManager
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.Bundle
+import android.util.Log
+import android.view.WindowManager
+
+class FullScreenActivity : Activity() {
+    public override fun onCreate(savedInstanceState: Bundle?) {
+        Log.d(LOG_TAG, "onCreate")
+        super.onCreate(savedInstanceState)
+        turnScreenOnAndKeyguardOff()
+        forceMainActivityReload()
+        finish()
+    }
+
+    private fun forceMainActivityReload() {
+        val pm: PackageManager = getPackageManager()
+        val launchIntent: Intent? =
+            pm.getLaunchIntentForPackage(getApplicationContext().getPackageName())
+        launchIntent?.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+        launchIntent?.addFlags(Intent.FLAG_FROM_BACKGROUND)
+        startActivity(launchIntent)
+    }
+
+    protected override fun onDestroy() {
+        super.onDestroy()
+        Log.d(LOG_TAG, "onDestroy")
+        turnScreenOffAndKeyguardOn()
+    }
+
+    private fun turnScreenOnAndKeyguardOff() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+            Log.d(LOG_TAG, "setShowWhenLocked")
+            setShowWhenLocked(true)
+            setTurnScreenOn(true)
+        } else {
+            Log.d(LOG_TAG, "addFlags")
+            getWindow().addFlags(
+                WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
+                        or WindowManager.LayoutParams.FLAG_ALLOW_LOCK_WHILE_SCREEN_ON
+            )
+        }
+        val keyguardManager: KeyguardManager? = getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager?
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && keyguardManager != null) {
+            keyguardManager?.requestDismissKeyguard(this, object : KeyguardManager.KeyguardDismissCallback() {
+                override fun onDismissCancelled() {
+                    super.onDismissCancelled()
+                    Log.d(LOG_TAG, "canceled")
+                }
+
+                override fun onDismissError() {
+                    super.onDismissError()
+                    Log.d(LOG_TAG, "onDismissError")
+                }
+
+                override fun onDismissSucceeded() {
+                    super.onDismissSucceeded()
+                    Log.d(LOG_TAG, "onDismissSucceeded")
+                }
+            })
+        }
+    }
+
+    private fun turnScreenOffAndKeyguardOn() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+            setShowWhenLocked(false)
+            setTurnScreenOn(false)
+        } else {
+            getWindow().clearFlags(
+                WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
+                        or WindowManager.LayoutParams.FLAG_ALLOW_LOCK_WHILE_SCREEN_ON
+            )
+        }
+    }
+
+    companion object {
+        private const val LOG_TAG = "FullScreenActivity"
+    }
+}

--- a/src/android/com/adobe/phonegap/push/PushConstants.kt
+++ b/src/android/com/adobe/phonegap/push/PushConstants.kt
@@ -110,4 +110,5 @@ object PushConstants {
   const val CLEAR_NOTIFICATION: String = "clearNotification"
   const val MESSAGE_ID: String = "google.message_id"
   const val IS_ENABLED: String = "isEnabled"
+  const val FULL_SCREEN_NOTIFICATION: String = "full-screen-notification"
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add full screen activity, fix for target Android API 31

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Deprecated version: 
https://github.com/havesource/cordova-plugin-push/pull/137

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I had problem with wakening up Samsung phones. When phone is in dose mode notification is received but screen stay off and only sound is played. My requirement is to catch user attention.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Android 11 and 12.
In payload add:
```
'full-screen-notification': '1'
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
