### PR TITLE
feat(android): bump Kotlin version

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -61,7 +61,7 @@
       <preference name="GradlePluginGoogleServicesVersion" value="4.3.8" />
 
       <preference name="GradlePluginKotlinEnabled" value="true" />
-      <preference name="GradlePluginKotlinVersion" value="1.5.20" />
+      <preference name="GradlePluginKotlinVersion" value="1.7.10" />
     </config-file>
 
     <preference name="ANDROIDX_CORE_VERSION" default="1.6.+"/>


### PR DESCRIPTION
Raises Kotlin version required in Gradle to 1.7, since sticking to a rather old version 1.5 is starting to cause problems in projects depending on this plugin.
The resulting error is: `The binary version of its metadata is 1.7.1, expected version is 1.5.1`.
A related topic is: https://stackoverflow.com/a/74425347/1379714

## How Has This Been Tested?

Our build was broken with the above mentioned error. This change fixed it.
Other gradle/maven deps could also be updated, but introduced different requirements on the Target API.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
