### PR TITLE
feat(android)!: bump platform requirement cordova-android>=12.0.0

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -12,7 +12,7 @@
   - [Browser details](#browser-details)
     - [Browser Support](#browser-support)
   - [iOS details](#ios-details)
-    - [System & Cordova Requirements](#system--cordova-requirements)
+    - [System \& Cordova Requirements](#system--cordova-requirements)
     - [Bitcode](#bitcode)
     - [CocoaPods](#cocoapods)
       - [Common CocoaPod Installation issues](#common-cocoapod-installation-issues)
@@ -27,6 +27,7 @@
 | 1.0.0          | 10.0.0      | 8.0.0           | 5.1.1       | 1.8.0     |
 | 2.0.0          | 10.0.0      | 8.0.0           | 6.0.0       | 1.8.0     |
 | 3.0.0          | 10.0.0      | 9.0.0           | 6.0.0       | 1.8.0     |
+| 4.0.0          | 10.0.0      | 12.0.0          | 6.0.0       | 1.8.0     |
 
 To install from the command line:
 

--- a/docs/PLATFORM_SUPPORT.md
+++ b/docs/PLATFORM_SUPPORT.md
@@ -1,5 +1,13 @@
 ## Supported Platforms
 
+### Version 4.x.x
+
+- Cordova CLI (10.0.0 or newer)
+- Android (`cordova-android` 12.0.0 or higher)
+- Browser
+- iOS (`cordova-ios` 6.0.0 or higher)
+- Windows Universal (not Windows Phone 8)
+
 ### Version 3.x.x
 
 - Cordova CLI (10.0.0 or newer)

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,11 @@
             "cordova": ">=10.0.0",
             "cordova-android": ">=9.0.0",
             "cordova-ios": ">=6.0.0"
+          },
+          "4.0.0": {
+            "cordova": ">=10.0.0",
+            "cordova-android": ">=12.0.0",
+            "cordova-ios": ">=6.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,11 @@
   },
   "engines": {
     "cordovaDependencies": {
+      "4.0.0": {
+        "cordova": ">=10.0.0",
+        "cordova-android": ">=12.0.0",
+        "cordova-ios": ">=6.0.0"
+      },
       "3.0.0": {
         "cordova": ">=10.0.0",
         "cordova-android": ">=9.0.0",

--- a/plugin.xml
+++ b/plugin.xml
@@ -14,7 +14,7 @@
 
   <engines>
     <engine name="cordova" version=">=10.0.0"/>
-    <engine name="cordova-android" version=">=9.0.0"/>
+    <engine name="cordova-android" version=">=12.0.0"/>
     <engine name="cordova-ios" version=">=6.0.0"/>
   </engines>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Bump cordova-android engine requirement

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

n/a

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Since Android 13 (SDK 33) APIs are being added to the source code, we should increase the cordova-android requirement to `>=12.0.0` which supports SDK 33 minimum.

Anything lower will not build successfully out of the box.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

plugin add

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
