### PR TITLE
fix(android): add BackgroundHandlerActivity protectionLevel signature

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -35,6 +35,8 @@
       <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
       <uses-permission android:name="${applicationId}.permission.PushHandlerActivity"/>
       <permission android:name="${applicationId}.permission.PushHandlerActivity" android:protectionLevel="signature"></permission>
+      <uses-permission android:name="${applicationId}.permission.BackgroundHandlerActivity"/>
+      <permission android:name="${applicationId}.permission.BackgroundHandlerActivity" android:protectionLevel="signature"></permission>
     </config-file>
 
     <config-file target="AndroidManifest.xml" parent="/manifest/application">


### PR DESCRIPTION
We had an external audit to our App which uses this plugin.

During the audit, it was found that the activity "com.adobe.phonegap.push.BackgroundHandlerActivity" is
configured with the following permissions: `com.seamlink.gatewaybox.chporto.permission.BackgroundHandlerActivity [android:exported=true]` and that this allows other applications running on the device to access and interact with this Activity. This can become serious if this Activity contains sensitive features or information.

It was recomended that we configure the permissions protection level to "signature", because the Activity should only be accessed by applications with the same signature or certificate.

## Description
Changed the protection level of BackgroundHandlerActivity to only be used by applications with the same signature or certificate.

I've tested this change and could receive notification with the app running, in the background or not running at all.

## Related Issue


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
