### PR TITLE
fix(android): clipped notification text and expand arrow

### DIFF
--- a/src/android/com/adobe/phonegap/push/FCMService.kt
+++ b/src/android/com/adobe/phonegap/push/FCMService.kt
@@ -916,7 +916,7 @@ class FCMService : FirebaseMessagingService() {
             }
 
             mBuilder.setContentText(fromHtml(messageStr))
-            mBuilder.setStyle(bigText)
+            mBuilder.setStyle(NotificationCompat.BigTextStyle().bigText(messageStr))
           }
         }
       }


### PR DESCRIPTION
## Related Issue
Fixes #263

## Motivation and Context
Notification was being clipped and the expand arrow was disabled.

## How Has This Been Tested?
Tested with notifications sent to Android 6, 8 and 10.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
