### PR TITLE
fix(ios): add missing critical to typings

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -221,6 +221,14 @@ declare namespace PhonegapPluginPush {
 			 */
 			categories?: CategoryArray
 			/**
+			 * If `true` the device can show up critical alerts. (Possible since iOS 12 with a special entitlement)
+			 * Default is false|"false".
+       * Note: the value you set this option to the first time you call the init method will be how the application always acts.
+       * Once this is set programmatically in the init method it can only be changed manually by the user in Settings > Notifications > `App Name`.
+       * This is normal iOS behaviour.
+			 */
+			critical?: boolean
+			/**
 			 * Whether to use prod or sandbox GCM setting. Defaults to false.
 			 */
 			fcmSandbox?: boolean


### PR DESCRIPTION
Add the missing iOS specific`critical` to the TypeScript typings

## Description

According to the [API docs](https://github.com/havesource/cordova-plugin-push/blob/master/docs/API.md#ios) and the code a `critical` property is supported on iOS, but it is missing in the TypeScript typings. The PR adds it.

## Related Issue
(https://github.com/havesource/cordova-plugin-push/issues/270)

## Motivation and Context
Fixes TS compilation issues when using "critical" notifications on iOS.

## How Has This Been Tested?
Used the updated typings in my own test project

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
