### PR TITLE
Fix the issue that causes the 'registration' event not to be triggered

### DIFF
--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -293,9 +293,11 @@
             if(isGcmEnabled && [[self fcmSenderId] length] > 0) {
                 NSLog(@"Using FCM Notification");
                 [self setUsesFCM: YES];
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    if([FIRApp defaultApp] == nil)
+                // Execute after 1 second to ensure it is executed after the registerForRemoteNotifications method if the push permission is already granted
+                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                    if ([FIRApp defaultApp] == nil) {
                         [FIRApp configure];
+                    }
                     [self initRegistration];
                 });
             } else {


### PR DESCRIPTION
We noticed an issue after upgrading the Firebase iOS messaging SDK to the latest version (10.29.0). The "registration" event wasn't triggered anymore when the app starts.

This issue arises because the initRegistration method fails with the error 'The operation couldn’t be completed. No APNS token specified before fetching FCM Token' when calling the init method of the plugin. This occurs because initRegistration is executed before registerForRemoteNotifications when the push permissions are already granted.

We tested this fix in local and production and everything works as expected.