### PR TITLE
feat!(ios): bump firebase 10.24.0 w/ improve FCM init & logging

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -93,11 +93,12 @@
   </platform>
 
   <platform name="ios">
-    <preference name="IOS_FIREBASE_MESSAGING_VERSION" default="~> 8.1.1"/>
+    <preference name="IOS_FIREBASE_MESSAGING_VERSION" default="~> 10.24.0"/>
 
     <config-file target="config.xml" parent="/*">
       <feature name="PushNotification">
         <param name="ios-package" value="PushPlugin"/>
+        <param name="onload" value="true" />
       </feature>
     </config-file>
 

--- a/src/ios/AppDelegate+notification.m
+++ b/src/ios/AppDelegate+notification.m
@@ -79,12 +79,12 @@ NSString *const pushPluginApplicationDidBecomeActiveNotification = @"pushPluginA
 }
 
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
-    NSLog(@"didReceiveNotification with fetchCompletionHandler");
+    NSLog(@"[PushPlugin]didReceiveNotification with fetchCompletionHandler");
 
     // app is in the background or inactive, so only call notification callback if this is a silent push
     if (application.applicationState != UIApplicationStateActive) {
 
-        NSLog(@"app in-active");
+        NSLog(@"[PushPlugin] app in-active");
 
         // do some convoluted logic to find out if this should be a silent push.
         long silent = 0;
@@ -97,7 +97,7 @@ NSString *const pushPluginApplicationDidBecomeActiveNotification = @"pushPluginA
         }
 
         if (silent == 1) {
-            NSLog(@"this should be a silent push");
+            NSLog(@"[PushPlugin] this should be a silent push");
             void (^safeHandler)(UIBackgroundFetchResult) = ^(UIBackgroundFetchResult result){
                 dispatch_async(dispatch_get_main_queue(), ^{
                     completionHandler(result);
@@ -112,10 +112,10 @@ NSString *const pushPluginApplicationDidBecomeActiveNotification = @"pushPluginA
 
             id notId = [userInfo objectForKey:@"notId"];
             if (notId != nil) {
-                NSLog(@"Push Plugin notId %@", notId);
+                NSLog(@"[PushPlugin] notId %@", notId);
                 [pushHandler.handlerObj setObject:safeHandler forKey:notId];
             } else {
-                NSLog(@"Push Plugin notId handler");
+                NSLog(@"[PushPlugin] notId handler");
                 [pushHandler.handlerObj setObject:safeHandler forKey:@"handler"];
             }
 
@@ -123,8 +123,7 @@ NSString *const pushPluginApplicationDidBecomeActiveNotification = @"pushPluginA
             pushHandler.isInline = NO;
             [pushHandler notificationReceived];
         } else {
-            NSLog(@"just put it in the shade");
-            //save it for later
+            NSLog(@"[PushPlugin] Save push for later");
             self.launchNotification = userInfo;
             completionHandler(UIBackgroundFetchResultNewData);
         }
@@ -153,12 +152,12 @@ NSString *const pushPluginApplicationDidBecomeActiveNotification = @"pushPluginA
 
 - (void)pushPluginOnApplicationDidBecomeActive:(NSNotification *)notification {
 
-    NSLog(@"active");
+    NSLog(@"[PushPlugin] pushPluginOnApplicationDidBecomeActive");
     
     NSString *firstLaunchKey = @"firstLaunchKey";
     NSUserDefaults *defaults = [[NSUserDefaults alloc] initWithSuiteName:@"phonegap-plugin-push"];
     if (![defaults boolForKey:firstLaunchKey]) {
-        NSLog(@"application first launch: remove badge icon number");
+        NSLog(@"[PushPlugin] application first launch: remove badge icon number");
         [defaults setBool:YES forKey:firstLaunchKey];
         [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
     }
@@ -167,11 +166,11 @@ NSString *const pushPluginApplicationDidBecomeActiveNotification = @"pushPluginA
 
     PushPlugin *pushHandler = [self getCommandInstance:@"PushNotification"];
     if (pushHandler.clearBadge) {
-        NSLog(@"PushPlugin clearing badge");
+        NSLog(@"[PushPlugin] clearing badge");
         //zero badge
         application.applicationIconBadgeNumber = 0;
     } else {
-        NSLog(@"PushPlugin skip clear badge");
+        NSLog(@"[PushPlugin] skip clear badge");
     }
 
     if (self.launchNotification) {
@@ -190,7 +189,7 @@ NSString *const pushPluginApplicationDidBecomeActiveNotification = @"pushPluginA
        willPresentNotification:(UNNotification *)notification
          withCompletionHandler:(void (^)(UNNotificationPresentationOptions options))completionHandler
 {
-    NSLog( @"NotificationCenter Handle push from foreground" );
+    NSLog(@"[PushPlugin] NotificationCenter Handle push from foreground");
     // custom code to handle push while app is in the foreground
     PushPlugin *pushHandler = [self getCommandInstance:@"PushNotification"];
     pushHandler.notificationMessage = notification.request.content.userInfo;
@@ -210,11 +209,11 @@ NSString *const pushPluginApplicationDidBecomeActiveNotification = @"pushPluginA
 didReceiveNotificationResponse:(UNNotificationResponse *)response
          withCompletionHandler:(void(^)(void))completionHandler
 {
-    NSLog(@"Push Plugin didReceiveNotificationResponse: actionIdentifier %@, notification: %@", response.actionIdentifier,
+    NSLog(@"[PushPlugin] didReceiveNotificationResponse: actionIdentifier %@, notification: %@", response.actionIdentifier,
           response.notification.request.content.userInfo);
     NSMutableDictionary *userInfo = [response.notification.request.content.userInfo mutableCopy];
     [userInfo setObject:response.actionIdentifier forKey:@"actionCallback"];
-    NSLog(@"Push Plugin userInfo %@", userInfo);
+    NSLog(@"[PushPlugin] userInfo %@", userInfo);
 
     switch ([UIApplication sharedApplication].applicationState) {
         case UIApplicationStateActive:
@@ -228,7 +227,7 @@ didReceiveNotificationResponse:(UNNotificationResponse *)response
         }
         case UIApplicationStateInactive:
         {
-            NSLog(@"coldstart");
+            NSLog(@"[PushPlugin] coldstart");
             
             if([response.actionIdentifier rangeOfString:@"UNNotificationDefaultActionIdentifier"].location == NSNotFound) {
                 self.launchNotification = userInfo;
@@ -256,10 +255,10 @@ didReceiveNotificationResponse:(UNNotificationResponse *)response
 
             id notId = [userInfo objectForKey:@"notId"];
             if (notId != nil) {
-                NSLog(@"Push Plugin notId %@", notId);
+                NSLog(@"[PushPlugin] notId %@", notId);
                 [pushHandler.handlerObj setObject:safeHandler forKey:notId];
             } else {
-                NSLog(@"Push Plugin notId handler");
+                NSLog(@"[PushPlugin] notId handler");
                 [pushHandler.handlerObj setObject:safeHandler forKey:@"handler"];
             }
 

--- a/src/ios/PushPlugin.h
+++ b/src/ios/PushPlugin.h
@@ -41,6 +41,8 @@
     BOOL    forceShow;
 
     NSMutableDictionary *handlerObj;
+    NSMutableDictionary *iOSOptions;
+
     void (^completionHandler)(UIBackgroundFetchResult);
 
     BOOL ready;
@@ -55,7 +57,9 @@
 @property BOOL coldstart;
 @property BOOL clearBadge;
 @property BOOL forceShow;
+
 @property (nonatomic, strong) NSMutableDictionary *handlerObj;
+@property (nonatomic, strong) NSMutableDictionary *iOSOptions;
 
 - (void)init:(CDVInvokedUrlCommand*)command;
 - (void)unregister:(CDVInvokedUrlCommand*)command;

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -83,6 +83,9 @@
 
     if(![self usesFCM]) {
         NSLog(@"[PushPlugin] Falling back onto APNS");
+    } else {
+        NSLog(@"[PushPlugin] Configuring Firebase App for FCM");
+        [FIRApp configure];
     }
 }
 
@@ -367,15 +370,8 @@
 
     if([self usesFCM]) {
         NSLog(@"[PushPlugin] Setting APNS Token to FCM");
-        dispatch_async(dispatch_get_main_queue(), ^{
-            if([FIRApp defaultApp] == nil)
-                [FIRApp configure];
-
-            // Ensure the APNS token is passed to Firebase Messaging
-            [[FIRMessaging messaging] setAPNSToken:deviceToken];
-
-            [self initFirebaseMessaging:[self iOSOptions]];
-        });
+        [[FIRMessaging messaging] setAPNSToken:deviceToken];
+        [self initFirebaseMessaging:[self iOSOptions]];
     }
 
     // Check what Notifications the user has turned on.  We registered for all three, but they may have manually disabled some or all of them.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Bump Firebase/Messaging to 10.24.0
  - Matches with `cordova-plugin-firebasex` so it wont case any conflicts.
  - Another PR will be coming down the pipeline to use the latest version 11.1.0
- Improved Logging
  - Added some logging messages
  - Prefixed log messages with `[PushPlugin]`
- Improved/Fixed FCM initialization process
  - Decide if FCM is available during `pluginInitialize` process.
    - FCM is used when `GoogleService-Info.plist` exists and contains the values `IS_GCM_ENABLED == TRUE` and `GCM_SENDER_ID != nil`
    - Will fallback onto APNS.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #283
Resolves #202 
Resolves #170 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

- Provide a modern version of Firebase/Messaging (Not the latest)
- Allow it to work with other plugins such as `cordova-plugin-firebasex` with out conflicts or breaks in behavior.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Created Cordova Sample App
- Configured it following docs to init the plugin
- Dropped a test APNS payload onto simulator
- Composed a Firebase Cloud Message test from Firebase Console and sent it to the "registration token" that was provided from log output.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
