### PR TITLE
fix(android): clipped notification text and expand arrow

### DIFF
--- a/src/android/com/adobe/phonegap/push/FCMService.kt
+++ b/src/android/com/adobe/phonegap/push/FCMService.kt
@@ -906,17 +906,16 @@ class FCMService : FirebaseMessagingService() {
           setNotification(notId, "")
 
           message?.let { messageStr ->
-            val bigText = NotificationCompat.BigTextStyle().run {
-              bigText(fromHtml(messageStr))
-              setBigContentTitle(fromHtml(it.getString(PushConstants.TITLE)))
+            val bigText = NotificationCompat.BigTextStyle()
+              .bigText(fromHtml(messageStr))
+              .setBigContentTitle(fromHtml(it.getString(PushConstants.TITLE)))
 
-              it.getString(PushConstants.SUMMARY_TEXT)?.let { summaryText ->
-                setSummaryText(fromHtml(summaryText))
-              }
+            it.getString(PushConstants.SUMMARY_TEXT)?.let { summaryText ->
+              bigText.setSummaryText(fromHtml(summaryText))
             }
 
             mBuilder.setContentText(fromHtml(messageStr))
-            mBuilder.setStyle(NotificationCompat.BigTextStyle().bigText(messageStr))
+            mBuilder.setStyle(bigText)
           }
         }
       }

--- a/src/android/com/adobe/phonegap/push/FCMService.kt
+++ b/src/android/com/adobe/phonegap/push/FCMService.kt
@@ -916,7 +916,7 @@ class FCMService : FirebaseMessagingService() {
             }
 
             mBuilder.setContentText(fromHtml(messageStr))
-            mBuilder.setStyle(bigText)
+            mBuilder.setStyle(NotificationCompat.BigTextStyle().bigText(messageStr))
           }
         }
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fixes the issue where the notification was being clipped and the expand arrow was displayed.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #263
Closes #268

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Resolves above issues

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on Android SDK 24 & 34

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
