### PR TITLE
chore(ios)!: remove unused & deprecated code & styling formatting

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -134,7 +134,6 @@ The following properties are used if you want use GCM on iOS.
 
 | Attribute        | Type      | Default | Description                                                    |
 | ---------------- | --------- | ------- | -------------------------------------------------------------- |
-| `ios.fcmSandbox` | `boolean` | `false` | Whether to use prod or sandbox GCM setting. Defaults to false. |
 | `ios.topics`     | `array`   | `[]`    | Optional. If the array contains one or more strings each string will be used to subscribe to a FcmPubSub topic. |
 
 ##### How GCM on iOS works.
@@ -145,12 +144,7 @@ What happens is on the device side is that it registers with APNS, then that reg
 
 When you send a message to GCM using that ID, what it does is look up the APNS registration ID on it's side and forward the message you sent to GCM on to APSN to deliver to your iOS device.
 
-Make sure that the certificate you build with matches your `fcmSandbox` value.
-
-* If you build your app as development and set `fcmSandbox: false` it will fail.
-* If you build your app as production and set `fcmSandbox: true` it will fail.
-* If you build your app as development and set `fcmSandbox: true` but haven't uploaded the development certs to Google it will fail.
-* If you build your app as production and set `fcmSandbox: false` but haven't uploaded the production certs to Google it will fail.
+Unlike GCM, FCM automatically determines whether to use the sandbox or production environment based on factors such as the app's provisioning profile, APNs certificate, and distribution method (e.g., App Store, TestFlight, or simulator).
 
 > Note: The integration between GCM and APNS is a bit finicky. Personally, I feel it is much better to send pushes to Android using GCM and pushes to iOS using APNS which this plugin does support.
 

--- a/src/ios/PushPlugin.h
+++ b/src/ios/PushPlugin.h
@@ -29,8 +29,6 @@
 #import <Cordova/CDVPlugin.h>
 #import <PushKit/PushKit.h>
 
-@protocol GGLInstanceIDDelegate;
-@protocol GCMReceiverDelegate;
 @interface PushPlugin : CDVPlugin
 {
     NSDictionary *notificationMessage;

--- a/src/ios/PushPlugin.h
+++ b/src/ios/PushPlugin.h
@@ -38,8 +38,6 @@
 
     NSMutableDictionary *handlerObj;
     void (^completionHandler)(UIBackgroundFetchResult);
-
-    BOOL ready;
 }
 
 @property (nonatomic, copy) NSString *callbackId;

--- a/src/ios/PushPlugin.h
+++ b/src/ios/PushPlugin.h
@@ -61,8 +61,6 @@
 - (void)setNotificationMessage:(NSDictionary *)notification;
 - (void)notificationReceived;
 
-- (void)willSendDataMessageWithID:(NSString *)messageID error:(NSError *)error;
-
 // VoIP Features
 - (void)pushRegistry:(PKPushRegistry *)registry didUpdatePushCredentials:(PKPushCredentials *)credentials forType:(NSString *)type;
 - (void)pushRegistry:(PKPushRegistry *)registry didReceiveIncomingPushWithPayload:(PKPushPayload *)payload forType:(NSString *)type;

--- a/src/ios/PushPlugin.h
+++ b/src/ios/PushPlugin.h
@@ -62,7 +62,6 @@
 - (void)notificationReceived;
 
 - (void)willSendDataMessageWithID:(NSString *)messageID error:(NSError *)error;
-- (void)didSendDataMessageWithID:(NSString *)messageID;
 
 // VoIP Features
 - (void)pushRegistry:(PKPushRegistry *)registry didUpdatePushCredentials:(PKPushCredentials *)credentials forType:(NSString *)type;

--- a/src/ios/PushPlugin.h
+++ b/src/ios/PushPlugin.h
@@ -78,7 +78,6 @@
 
 // FCM Features
 @property(nonatomic, assign) BOOL usesFCM;
-@property(nonatomic, strong) NSNumber *fcmSandbox;
 @property(nonatomic, strong) NSString *fcmSenderId;
 @property(nonatomic, strong) NSDictionary *fcmRegistrationOptions;
 @property(nonatomic, strong) NSString *fcmRegistrationToken;

--- a/src/ios/PushPlugin.h
+++ b/src/ios/PushPlugin.h
@@ -33,7 +33,6 @@
 {
     NSDictionary *notificationMessage;
     BOOL    isInline;
-    NSString *callback;
     BOOL    clearBadge;
     BOOL    forceShow;
 
@@ -44,7 +43,6 @@
 }
 
 @property (nonatomic, copy) NSString *callbackId;
-@property (nonatomic, copy) NSString *callback;
 
 @property (nonatomic, strong) NSDictionary *notificationMessage;
 @property BOOL isInline;

--- a/src/ios/PushPlugin.h
+++ b/src/ios/PushPlugin.h
@@ -79,7 +79,6 @@
 // FCM Features
 @property(nonatomic, assign) BOOL usesFCM;
 @property(nonatomic, strong) NSString *fcmSenderId;
-@property(nonatomic, strong) NSString *fcmRegistrationToken;
 @property(nonatomic, strong) NSArray *fcmTopics;
 
 @end

--- a/src/ios/PushPlugin.h
+++ b/src/ios/PushPlugin.h
@@ -79,7 +79,6 @@
 // FCM Features
 @property(nonatomic, assign) BOOL usesFCM;
 @property(nonatomic, strong) NSString *fcmSenderId;
-@property(nonatomic, strong) NSDictionary *fcmRegistrationOptions;
 @property(nonatomic, strong) NSString *fcmRegistrationToken;
 @property(nonatomic, strong) NSArray *fcmTopics;
 

--- a/src/ios/PushPlugin.h
+++ b/src/ios/PushPlugin.h
@@ -33,7 +33,6 @@
 {
     NSDictionary *notificationMessage;
     BOOL    isInline;
-    NSString *notificationCallbackId;
     NSString *callback;
     BOOL    clearBadge;
     BOOL    forceShow;
@@ -45,7 +44,6 @@
 }
 
 @property (nonatomic, copy) NSString *callbackId;
-@property (nonatomic, copy) NSString *notificationCallbackId;
 @property (nonatomic, copy) NSString *callback;
 
 @property (nonatomic, strong) NSDictionary *notificationMessage;

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -49,7 +49,6 @@
 
 @synthesize usesFCM;
 @synthesize fcmSenderId;
-@synthesize fcmRegistrationToken;
 @synthesize fcmTopics;
 
 -(void)initRegistration;
@@ -59,8 +58,6 @@
             NSLog(@"[PushPlugin] Error getting FCM registration token: %@", error);
         } else {
             NSLog(@"[PushPlugin] FCM registration token: %@", token);
-
-            [self setFcmRegistrationToken: token];
 
             NSString* message = [NSString stringWithFormat:@"Remote InstanceID token: %@", token];
 

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -77,11 +77,6 @@
 #endif
 }
 
-// contains error info
-- (void)didSendDataMessageWithID:messageID {
-    NSLog(@"[PushPlugin] didSendDataMessageWithID");
-}
-
 - (void)willSendDataMessageWithID:messageID error:error {
     NSLog(@"[PushPlugin] willSendDataMessageWithID");
 }

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -23,9 +23,6 @@
  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-//  See GGLInstanceID.h
-#define GMP_NO_MODULES true
-
 #import "PushPlugin.h"
 #import "AppDelegate+notification.h"
 

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -59,8 +59,6 @@
         } else {
             NSLog(@"[PushPlugin] FCM registration token: %@", token);
 
-            NSString* message = [NSString stringWithFormat:@"Remote InstanceID token: %@", token];
-
             id topics = [self fcmTopics];
             if (topics != nil) {
                 for (NSString *topic in topics) {

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -35,12 +35,10 @@
 @synthesize notificationMessage;
 @synthesize isInline;
 @synthesize coldstart;
-
 @synthesize callbackId;
 @synthesize clearBadge;
 @synthesize forceShow;
 @synthesize handlerObj;
-
 @synthesize usesFCM;
 @synthesize fcmSenderId;
 @synthesize fcmTopics;
@@ -252,7 +250,6 @@
                     NSLog(@"[PushPlugin] Adding category %@", key);
                     [categories addObject:notificationCategory];
                 }
-
             }
 
             UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
@@ -263,8 +260,6 @@
                                                      selector:@selector(handleNotificationSettings:)
                                                          name:pushPluginApplicationDidBecomeActiveNotification
                                                        object:nil];
-
-
 
             // Read GoogleService-Info.plist
             NSString *path = [[NSBundle mainBundle] pathForResource:@"GoogleService-Info" ofType:@"plist"];
@@ -297,7 +292,6 @@
                     [self performSelector:@selector(notificationReceived) withObject:nil afterDelay: 0.5];
                 });
             }
-
         }];
     }
 }
@@ -337,7 +331,6 @@
 #endif
 
 #if !TARGET_IPHONE_SIMULATOR
-
     // Check what Notifications the user has turned on.  We registered for all three, but they may have manually disabled some or all of them.
 
     UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
@@ -348,8 +341,6 @@
             [weakSelf registerWithToken: token];
         }
     }];
-
-
 #endif
 }
 
@@ -385,7 +376,6 @@
     {
         NSMutableDictionary* message = [NSMutableDictionary dictionaryWithCapacity:4];
         NSMutableDictionary* additionalData = [NSMutableDictionary dictionaryWithCapacity:4];
-
 
         for (id key in notificationMessage) {
             if ([key isEqualToString:@"aps"]) {
@@ -538,7 +528,6 @@
     [pluginResult setKeepCallbackAsBool:YES];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackId];
 }
-
 
 -(void)failWithMessage:(NSString *)myCallbackId withMsg:(NSString *)message withError:(NSError *)error
 {

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -31,7 +31,6 @@
 
 @import Firebase;
 @import FirebaseCore;
-// @import FirebaseInstanceID;
 @import FirebaseMessaging;
 
 @implementation PushPlugin : CDVPlugin

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -49,7 +49,6 @@
 
 @synthesize usesFCM;
 @synthesize fcmSenderId;
-@synthesize fcmRegistrationOptions;
 @synthesize fcmRegistrationToken;
 @synthesize fcmTopics;
 

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -48,7 +48,6 @@
 @synthesize handlerObj;
 
 @synthesize usesFCM;
-@synthesize fcmSandbox;
 @synthesize fcmSenderId;
 @synthesize fcmRegistrationOptions;
 @synthesize fcmRegistrationToken;
@@ -311,16 +310,6 @@
             } else {
                 NSLog(@"[PushPlugin] Using APNS Notification");
                 [self setUsesFCM:NO];
-            }
-            id fcmSandboxArg = [iosOptions objectForKey:@"fcmSandbox"];
-
-            [self setFcmSandbox:@NO];
-            if ([self usesFCM] &&
-                (([fcmSandboxArg isKindOfClass:[NSString class]] && [fcmSandboxArg isEqualToString:@"true"]) ||
-                 [fcmSandboxArg boolValue]))
-            {
-                NSLog(@"[PushPlugin] Using FCM Sandbox");
-                [self setFcmSandbox:@YES];
             }
 
             if (notificationMessage) {            // if there is a pending startup notification

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -37,7 +37,6 @@
 @synthesize coldstart;
 
 @synthesize callbackId;
-@synthesize notificationCallbackId;
 @synthesize callback;
 @synthesize clearBadge;
 @synthesize forceShow;

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -37,7 +37,6 @@
 @synthesize coldstart;
 
 @synthesize callbackId;
-@synthesize callback;
 @synthesize clearBadge;
 @synthesize forceShow;
 @synthesize handlerObj;

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -77,10 +77,6 @@
 #endif
 }
 
-- (void)willSendDataMessageWithID:messageID error:error {
-    NSLog(@"[PushPlugin] willSendDataMessageWithID");
-}
-
 - (void)unregister:(CDVInvokedUrlCommand*)command;
 {
     NSArray* topics = [command argumentAtIndex:0];

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -43,8 +43,7 @@
 @synthesize fcmSenderId;
 @synthesize fcmTopics;
 
--(void)initRegistration;
-{
+- (void)initRegistration {
     [[FIRMessaging messaging] tokenWithCompletion:^(NSString *token, NSError *error) {
         if (error != nil) {
             NSLog(@"[PushPlugin] Error getting FCM registration token: %@", error);
@@ -75,8 +74,7 @@
 #endif
 }
 
-- (void)unregister:(CDVInvokedUrlCommand*)command;
-{
+- (void)unregister:(CDVInvokedUrlCommand *)command {
     NSArray* topics = [command argumentAtIndex:0];
 
     if (topics != nil) {
@@ -91,8 +89,7 @@
     }
 }
 
-- (void)subscribe:(CDVInvokedUrlCommand*)command;
-{
+- (void)subscribe:(CDVInvokedUrlCommand *)command {
     NSString* topic = [command argumentAtIndex:0];
 
     if (topic != nil) {
@@ -107,8 +104,7 @@
     }
 }
 
-- (void)unsubscribe:(CDVInvokedUrlCommand*)command;
-{
+- (void)unsubscribe:(CDVInvokedUrlCommand *)command {
     NSString* topic = [command argumentAtIndex:0];
 
     if (topic != nil) {
@@ -123,8 +119,7 @@
     }
 }
 
-- (void)init:(CDVInvokedUrlCommand*)command;
-{
+- (void)init:(CDVInvokedUrlCommand *)command {
     NSMutableDictionary* options = [command.arguments objectAtIndex:0];
     NSMutableDictionary* iosOptions = [options objectForKey:@"ios"];
     id voipArg = [iosOptions objectForKey:@"voip"];
@@ -344,8 +339,7 @@
 #endif
 }
 
-- (NSString *)hexadecimalStringFromData:(NSData *)data
-{
+- (NSString *)hexadecimalStringFromData:(NSData *)data {
     NSUInteger dataLength = data.length;
     if (dataLength == 0) {
         return nil;
@@ -359,8 +353,7 @@
     return [hexString copy];
 }
 
-- (void)didFailToRegisterForRemoteNotificationsWithError:(NSError *)error
-{
+- (void)didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
     if (self.callbackId == nil) {
         NSLog(@"[PushPlugin] Unexpected call to didFailToRegisterForRemoteNotificationsWithError, ignoring: %@", error);
         return;
@@ -442,8 +435,7 @@
     }
 }
 
-- (void)clearNotification:(CDVInvokedUrlCommand *)command
-{
+- (void)clearNotification:(CDVInvokedUrlCommand *)command {
     NSNumber *notId = [command.arguments objectAtIndex:0];
     [[UNUserNotificationCenter currentNotificationCenter] getDeliveredNotificationsWithCompletionHandler:^(NSArray<UNNotification *> * _Nonnull notifications) {
         /*
@@ -464,8 +456,7 @@
     }];
 }
 
-- (void)setApplicationIconBadgeNumber:(CDVInvokedUrlCommand *)command
-{
+- (void)setApplicationIconBadgeNumber:(CDVInvokedUrlCommand *)command {
     NSMutableDictionary* options = [command.arguments objectAtIndex:0];
     int badge = [[options objectForKey:@"badge"] intValue] ?: 0;
 
@@ -476,16 +467,14 @@
     [self.commandDelegate sendPluginResult:commandResult callbackId:command.callbackId];
 }
 
-- (void)getApplicationIconBadgeNumber:(CDVInvokedUrlCommand *)command
-{
+- (void)getApplicationIconBadgeNumber:(CDVInvokedUrlCommand *)command {
     NSInteger badge = [UIApplication sharedApplication].applicationIconBadgeNumber;
 
     CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsInt:(int)badge];
     [self.commandDelegate sendPluginResult:commandResult callbackId:command.callbackId];
 }
 
-- (void)clearAllNotifications:(CDVInvokedUrlCommand *)command
-{
+- (void)clearAllNotifications:(CDVInvokedUrlCommand *)command {
     [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
 
     NSString* message = [NSString stringWithFormat:@"cleared all notifications"];
@@ -493,8 +482,7 @@
     [self.commandDelegate sendPluginResult:commandResult callbackId:command.callbackId];
 }
 
-- (void)hasPermission:(CDVInvokedUrlCommand *)command
-{
+- (void)hasPermission:(CDVInvokedUrlCommand *)command {
     id<UIApplicationDelegate> appDelegate = [UIApplication sharedApplication].delegate;
     if ([appDelegate respondsToSelector:@selector(checkUserHasRemoteNotificationsEnabledWithCompletionHandler:)]) {
         [appDelegate performSelector:@selector(checkUserHasRemoteNotificationsEnabledWithCompletionHandler:) withObject:^(BOOL isEnabled) {
@@ -506,8 +494,7 @@
     }
 }
 
--(void)successWithMessage:(NSString *)myCallbackId withMsg:(NSString *)message
-{
+- (void)successWithMessage:(NSString *)myCallbackId withMsg:(NSString *)message {
     if (myCallbackId != nil)
     {
         CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:message];
@@ -515,7 +502,7 @@
     }
 }
 
--(void)registerWithToken:(NSString*)token; {
+- (void)registerWithToken:(NSString *)token {
     // Send result to trigger 'registration' event but keep callback
     NSMutableDictionary* message = [NSMutableDictionary dictionaryWithCapacity:2];
     [message setObject:token forKey:@"registrationId"];
@@ -529,16 +516,14 @@
     [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackId];
 }
 
--(void)failWithMessage:(NSString *)myCallbackId withMsg:(NSString *)message withError:(NSError *)error
-{
+- (void)failWithMessage:(NSString *)myCallbackId withMsg:(NSString *)message withError:(NSError *)error {
     NSString        *errorMessage = (error) ? [NSString stringWithFormat:@"%@ - %@", message, [error localizedDescription]] : message;
     CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:errorMessage];
 
     [self.commandDelegate sendPluginResult:commandResult callbackId:myCallbackId];
 }
 
--(void) finish:(CDVInvokedUrlCommand*)command
-{
+- (void) finish:(CDVInvokedUrlCommand *)command {
     NSLog(@"[PushPlugin] finish called");
 
     [self.commandDelegate runInBackground:^ {
@@ -557,8 +542,7 @@
     }];
 }
 
--(void)stopBackgroundTask:(NSTimer*)timer
-{
+- (void)stopBackgroundTask:(NSTimer *)timer {
     UIApplication *app = [UIApplication sharedApplication];
 
     NSLog(@"[PushPlugin] stopBackgroundTask called");
@@ -575,8 +559,7 @@
 }
 
 
-- (void)pushRegistry:(PKPushRegistry *)registry didUpdatePushCredentials:(PKPushCredentials *)credentials forType:(NSString *)type
-{
+- (void)pushRegistry:(PKPushRegistry *)registry didUpdatePushCredentials:(PKPushCredentials *)credentials forType:(NSString *)type {
     if([credentials.token length] == 0) {
         NSLog(@"[PushPlugin] VoIP register error - No device token:");
         return;
@@ -592,20 +575,17 @@
     [self registerWithToken:sToken];
 }
 
-- (void)pushRegistry:(PKPushRegistry *)registry didReceiveIncomingPushWithPayload:(PKPushPayload *)payload forType:(NSString *)type
-{
+- (void)pushRegistry:(PKPushRegistry *)registry didReceiveIncomingPushWithPayload:(PKPushPayload *)payload forType:(NSString *)type {
     NSLog(@"[PushPlugin] VoIP Notification received");
     self.notificationMessage = payload.dictionaryPayload;
     [self notificationReceived];
 }
 
-- (void)handleNotificationSettings:(NSNotification *)notification
-{
+- (void)handleNotificationSettings:(NSNotification *)notification {
     [self handleNotificationSettingsWithAuthorizationOptions:nil];
 }
 
-- (void)handleNotificationSettingsWithAuthorizationOptions:(NSNumber *)authorizationOptionsObject
-{
+- (void)handleNotificationSettingsWithAuthorizationOptions:(NSNumber *)authorizationOptionsObject {
     UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
     UNAuthorizationOptions authorizationOptions = [authorizationOptionsObject unsignedIntegerValue];
 
@@ -638,8 +618,7 @@
     }];
 }
 
-- (void)registerForRemoteNotifications
-{
+- (void)registerForRemoteNotifications {
     [[UIApplication sharedApplication] registerForRemoteNotifications];
 }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -229,10 +229,6 @@ declare namespace PhonegapPluginPush {
 			 */
 			critical?: boolean
 			/**
-			 * Whether to use prod or sandbox GCM setting. Defaults to false.
-			 */
-			fcmSandbox?: boolean
-			/**
 			 * If the array contains one or more strings each string will be used to subscribe to a FcmPubSub topic. Defaults to [].
 			 */
 			topics?: string[]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Remove unused methods & properties/variables
- Remove some of the deprecated code/defines/protocols of GCM
  - This PR does not rename of variables
- Remove excessive newlines
- Cleanup formatting

Note: The `fcmSandbox` is an iOS option that replaced `gcmSandbox` in version 2.0.0 of the `phonegap-push-plugin` days, but when GCM was dropped, `fcmSandbox` did not actual configure anything. This option can be dropped since it was never used and also FCM automatically determines the environment type.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

N/A

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Cleanup code base

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Build and run app in simulator.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Refactor/Chore (non-breaking change, non-functionality change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
