### PR TITLE
feat(ios): extract settings into PushPluginSettings

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -117,8 +117,11 @@
 
     <source-file src="src/ios/AppDelegate+notification.m"/>
     <source-file src="src/ios/PushPlugin.m"/>
+    <source-file src="src/ios/PushPluginSettings.m"/>
+
     <header-file src="src/ios/AppDelegate+notification.h"/>
     <header-file src="src/ios/PushPlugin.h"/>
+    <header-file src="src/ios/PushPluginSettings.h"/>
 
     <framework src="PushKit.framework"/>
 

--- a/src/ios/PushPluginSettings.h
+++ b/src/ios/PushPluginSettings.h
@@ -1,0 +1,28 @@
+//
+//  PushPluginSettings.h
+//  cordovaTest
+//
+//  Created by Erisu on 2024/09/14.
+//
+
+#import <Foundation/Foundation.h>
+#import <UserNotifications/UserNotifications.h>
+
+@interface PushPluginSettings : NSObject
+
+@property (nonatomic, readonly) BOOL badgeEnabled;
+@property (nonatomic, readonly) BOOL soundEnabled;
+@property (nonatomic, readonly) BOOL alertEnabled;
+@property (nonatomic, readonly) BOOL criticalEnabled;
+@property (nonatomic, readonly) BOOL clearBadgeEnabled;
+@property (nonatomic, readonly) BOOL forceShowEnabled;
+@property (nonatomic, readonly) BOOL voipEnabled;
+
+@property (nonatomic, readonly, strong) NSArray *fcmTopics;
+@property (nonatomic, readonly, strong) NSSet<UNNotificationCategory *> *categories;
+
++ (instancetype)sharedInstance;
+
+- (void)updateSettingsWithOptions:(NSDictionary *)options;
+
+@end

--- a/src/ios/PushPluginSettings.m
+++ b/src/ios/PushPluginSettings.m
@@ -1,0 +1,179 @@
+//
+//  PushPluginSettings.m
+//  cordovaTest
+//
+//  Created by Erisu on 2024/09/14.
+//
+
+#import "PushPluginSettings.h"
+
+@interface PushPluginSettings ()
+
+@property (nonatomic, strong) NSMutableDictionary *settingsDictionary;
+
+@end
+
+@implementation PushPluginSettings
+
++ (instancetype)sharedInstance {
+    static PushPluginSettings *sharedInstance = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+      sharedInstance = [[self alloc] initWithDefaults];
+    });
+    return sharedInstance;
+}
+
+- (instancetype)initWithDefaults {
+    self = [super init];
+    if (self) {
+        self.settingsDictionary = [@{
+            @"badge" : @(NO),
+            @"sound" : @(NO),
+            @"alert" : @(NO),
+            @"critical" : @(NO),
+            @"clearBadge" : @(NO),
+            @"forceShow" : @(NO),
+            @"voip" : @(NO),
+            @"fcmTopics" : @[],
+            @"categories" : [NSSet set]
+        } mutableCopy];
+    }
+    return self;
+}
+
+- (void)updateSettingsWithOptions:(NSDictionary *)options {
+    for (NSString *key in options) {
+        if ([self.settingsDictionary objectForKey:key]) {
+            // Overrides the default setting if defined and apply the correct formatting based on the key.
+            if ([key isEqualToString:@"fcmTopics"]) {
+                self.settingsDictionary[key] = [self parseArrayOption:key fromOptions:options withDefault:nil];
+            } else if ([key isEqualToString:@"categories"]) {
+                self.settingsDictionary[key] = [self parseCategoriesFromOptions:options[key]];
+            } else {
+                self.settingsDictionary[key] = @([self parseOption:key fromOptions:options withDefault:NO]);
+            }
+        } else {
+            NSLog(@"[PushPlugin] Settings: Invalid option key: %@", key);
+        }
+    }
+
+    NSLog(@"[PushPlugin] Settings: %@", self.settingsDictionary);
+}
+
+- (BOOL)parseOption:(NSString *)key fromOptions:(NSDictionary *)options withDefault:(BOOL)defaultValue {
+    id option = [options objectForKey:key];
+    if ([option isKindOfClass:[NSString class]]) {
+        return [option isEqualToString:@"true"];
+    }
+    if ([option respondsToSelector:@selector(boolValue)]) {
+        return [option boolValue];
+    }
+    return defaultValue;
+}
+
+- (NSArray *)parseArrayOption:(NSString *)key fromOptions:(NSDictionary *)options withDefault:(NSArray *)defaultValue {
+    id option = [options objectForKey:key];
+    if ([option isKindOfClass:[NSArray class]]) {
+        return (NSArray *)option;
+    }
+    return defaultValue;
+}
+
+- (NSSet<UNNotificationCategory *> *)parseCategoriesFromOptions:(NSDictionary *)categoryOptions {
+    NSMutableSet<UNNotificationCategory *> *categoriesSet = [[NSMutableSet alloc] init];
+    if (categoryOptions != nil && [categoryOptions isKindOfClass:[NSDictionary class]]) {
+        for (id key in categoryOptions) {
+            NSDictionary *category = [categoryOptions objectForKey:key];
+            UNNotificationCategory *notificationCategory = [self createCategoryFromDictionary:category withIdentifier:key];
+            if (notificationCategory) {
+                [categoriesSet addObject:notificationCategory];
+            }
+        }
+    }
+    return categoriesSet;
+}
+
+- (UNNotificationCategory *)createCategoryFromDictionary:(NSDictionary *)category withIdentifier:(NSString *)identifier {
+    NSMutableArray<UNNotificationAction *> *actions = [[NSMutableArray alloc] init];
+
+    UNNotificationAction *yesAction = [self createActionFromDictionary:[category objectForKey:@"yes"]];
+    if (yesAction)
+        [actions addObject:yesAction];
+
+    UNNotificationAction *noAction = [self createActionFromDictionary:[category objectForKey:@"no"]];
+    if (noAction)
+        [actions addObject:noAction];
+
+    UNNotificationAction *maybeAction = [self createActionFromDictionary:[category objectForKey:@"maybe"]];
+    if (maybeAction)
+        [actions addObject:maybeAction];
+
+    return [UNNotificationCategory categoryWithIdentifier:identifier actions:actions intentIdentifiers:@[] options:UNNotificationCategoryOptionNone];
+}
+
+- (UNNotificationAction *)createActionFromDictionary:(NSDictionary *)dictionary {
+    if (![dictionary isKindOfClass:[NSDictionary class]]) {
+        return nil;
+    }
+
+    NSString *identifier = [dictionary objectForKey:@"identifier"];
+    NSString *title = [dictionary objectForKey:@"title"];
+
+    if (!title || !identifier) {
+        return nil;
+    }
+
+    UNNotificationActionOptions options = UNNotificationActionOptionNone;
+    id foreground = [dictionary objectForKey:@"foreground"];
+    if (foreground != nil && (([foreground isKindOfClass:[NSString class]] && [foreground isEqualToString:@"true"]) || [foreground boolValue])) {
+        options |= UNNotificationActionOptionForeground;
+    }
+
+    id destructive = [dictionary objectForKey:@"destructive"];
+    if (destructive != nil && (([destructive isKindOfClass:[NSString class]] && [destructive isEqualToString:@"true"]) || [destructive boolValue])) {
+        options |= UNNotificationActionOptionDestructive;
+    }
+
+    return [UNNotificationAction actionWithIdentifier:identifier title:title options:options];
+}
+
+#pragma mark - Getters for individual settings
+
+- (BOOL)badgeEnabled {
+    return [self.settingsDictionary[@"badge"] boolValue];
+}
+
+- (BOOL)soundEnabled {
+    return [self.settingsDictionary[@"sound"] boolValue];
+}
+
+- (BOOL)alertEnabled {
+    return [self.settingsDictionary[@"alert"] boolValue];
+}
+
+- (BOOL)criticalEnabled {
+    return [self.settingsDictionary[@"critical"] boolValue];
+}
+
+- (BOOL)clearBadgeEnabled {
+    return [self.settingsDictionary[@"clearBadge"] boolValue];
+}
+
+- (BOOL)forceShowEnabled {
+    return [self.settingsDictionary[@"forceShow"] boolValue];
+}
+
+- (BOOL)voipEnabled {
+    return [self.settingsDictionary[@"voip"] boolValue];
+}
+
+- (NSArray *)fcmTopics {
+    return self.settingsDictionary[@"fcmTopics"];
+}
+
+- (NSSet<UNNotificationCategory *> *)categories {
+    return self.settingsDictionary[@"categories"];
+}
+
+@end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Extract Push Plugin Settings

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

n/a

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

To extract and centralize logic related to creating and storing settings that are passed in from init process.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Build
- Run simulator
- Drop APNs payload
  - Included categories

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
