### PR TITLE
feat(ios)!: extract FCM related logic to PushPluginFCM

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -98,6 +98,7 @@
     <config-file target="config.xml" parent="/*">
       <feature name="PushNotification">
         <param name="ios-package" value="PushPlugin"/>
+        <param name="onload" value="true"/>
       </feature>
     </config-file>
 
@@ -117,10 +118,12 @@
 
     <source-file src="src/ios/AppDelegate+notification.m"/>
     <source-file src="src/ios/PushPlugin.m"/>
+    <source-file src="src/ios/PushPluginFCM.m"/>
     <source-file src="src/ios/PushPluginSettings.m"/>
 
     <header-file src="src/ios/AppDelegate+notification.h"/>
     <header-file src="src/ios/PushPlugin.h"/>
+    <header-file src="src/ios/PushPluginFCM.h"/>
     <header-file src="src/ios/PushPluginSettings.h"/>
 
     <framework src="PushKit.framework"/>

--- a/src/ios/AppDelegate+notification.h
+++ b/src/ios/AppDelegate+notification.h
@@ -9,8 +9,6 @@
 #import "AppDelegate.h"
 @import UserNotifications;
 
-extern NSString *const pushPluginApplicationDidBecomeActiveNotification;
-
 @interface AppDelegate (notification) <UNUserNotificationCenterDelegate>
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error;

--- a/src/ios/AppDelegate+notification.m
+++ b/src/ios/AppDelegate+notification.m
@@ -12,8 +12,6 @@
 
 static char launchNotificationKey;
 static char coldstartKey;
-NSString *const pushPluginApplicationDidBecomeActiveNotification = @"pushPluginApplicationDidBecomeActiveNotification";
-
 
 @implementation AppDelegate (notification)
 
@@ -180,8 +178,6 @@ NSString *const pushPluginApplicationDidBecomeActiveNotification = @"pushPluginA
         self.coldstart = [NSNumber numberWithBool:NO];
         [pushHandler performSelectorOnMainThread:@selector(notificationReceived) withObject:pushHandler waitUntilDone:NO];
     }
-
-    [[NSNotificationCenter defaultCenter] postNotificationName:pushPluginApplicationDidBecomeActiveNotification object:nil];
 }
 
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center

--- a/src/ios/PushPlugin.h
+++ b/src/ios/PushPlugin.h
@@ -65,7 +65,4 @@
 - (void)pushRegistry:(PKPushRegistry *)registry didUpdatePushCredentials:(PKPushCredentials *)credentials forType:(NSString *)type;
 - (void)pushRegistry:(PKPushRegistry *)registry didReceiveIncomingPushWithPayload:(PKPushPayload *)payload forType:(NSString *)type;
 
-// FCM Features
-@property(nonatomic, strong) NSArray *fcmTopics;
-
 @end

--- a/src/ios/PushPlugin.h
+++ b/src/ios/PushPlugin.h
@@ -66,8 +66,6 @@
 - (void)pushRegistry:(PKPushRegistry *)registry didReceiveIncomingPushWithPayload:(PKPushPayload *)payload forType:(NSString *)type;
 
 // FCM Features
-@property(nonatomic, assign) BOOL usesFCM;
-@property(nonatomic, strong) NSString *fcmSenderId;
 @property(nonatomic, strong) NSArray *fcmTopics;
 
 @end

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -51,6 +51,10 @@
 
 - (void)pluginInitialize {
     self.pushPluginFCM = [[PushPluginFCM alloc] initWithGoogleServicePlist];
+
+    if([self.pushPluginFCM isFCMEnabled]) {
+        [self.pushPluginFCM configureFirebase];
+    }
 }
 
 - (void)initRegistration {
@@ -188,11 +192,7 @@
                                                        object:nil];
 
             if ([self.pushPluginFCM isFCMEnabled]) {
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    if([FIRApp defaultApp] == nil)
-                        [FIRApp configure];
-                    [self initRegistration];
-                });
+                [self initRegistration];
             }
 
             if (notificationMessage) {            // if there is a pending startup notification

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -365,14 +365,16 @@
 }
 
 - (void)registerWithToken:(NSString *)token {
-    // Send result to trigger 'registration' event but keep callback
+    NSString* registrationType = @"APNS";
+    if ([self.pushPluginFCM isFCMEnabled]) {
+        registrationType = @"FCM";
+    }
+
     NSMutableDictionary* message = [NSMutableDictionary dictionaryWithCapacity:2];
     [message setObject:token forKey:@"registrationId"];
-    if ([self.pushPluginFCM isFCMEnabled]) {
-        [message setObject:@"FCM" forKey:@"registrationType"];
-    } else {
-        [message setObject:@"APNS" forKey:@"registrationType"];
-    }
+    [message setObject:registrationType forKey:@"registrationType"];
+
+    // Send result to trigger 'registration' event but keep callback
     CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:message];
     [pluginResult setKeepCallbackAsBool:YES];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackId];

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -57,19 +57,9 @@
 }
 
 - (void)setFCMTokenWithCompletion {
-#if TARGET_IPHONE_SIMULATOR
-    NSLog(@"[PushPlugin] Detected simulator. Will register an FCM token but pushing to simulator is not possible.");
-#endif
-
-    PushPluginSettings *settings = [PushPluginSettings sharedInstance];
-    [[FIRMessaging messaging] tokenWithCompletion:^(NSString *token, NSError *error) {
-        if (error != nil) {
-            NSLog(@"[PushPlugin] Error getting FCM registration token: %@", error);
-        } else {
-            NSLog(@"[PushPlugin] FCM registration token: %@", token);
-            [self.pushPluginFCM subscribeToTopics:settings.fcmTopics];
-            [self registerWithToken: token];
-        }
+    __weak __typeof(self) weakSelf = self;
+    [self.pushPluginFCM setTokenWithCompletion:^(NSString *token) {
+        [weakSelf registerWithToken:token];
     }];
 }
 

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -75,27 +75,39 @@
 }
 
 - (void)subscribe:(CDVInvokedUrlCommand *)command {
-    NSString* topic = [command argumentAtIndex:0];
+    if (!self.pushPluginFCM.isFCMEnabled) {
+        NSLog(@"The 'subscribe' API not allowed. FCM is not enabled.");
+        [self successWithMessage:command.callbackId withMsg:@"The 'subscribe' API not allowed. FCM is not enabled."];
+        return;
+    }
 
-    if (topic != nil) {
-        [self.pushPluginFCM subscribeToTopic:topic];
-        [self successWithMessage:command.callbackId withMsg:[NSString stringWithFormat:@"Successfully subscribe to topic %@", topic]];
-    } else {
+    NSString* topic = [command argumentAtIndex:0];
+    if (topic == nil) {
         NSLog(@"[PushPlugin] There is no topic to subscribe");
         [self successWithMessage:command.callbackId withMsg:@"There is no topic to subscribe"];
+        return;
     }
+
+    [self.pushPluginFCM subscribeToTopic:topic];
+    [self successWithMessage:command.callbackId withMsg:[NSString stringWithFormat:@"Successfully subscribe to topic %@", topic]];
 }
 
 - (void)unsubscribe:(CDVInvokedUrlCommand *)command {
-    NSString* topic = [command argumentAtIndex:0];
-
-    if (topic != nil) {
-        [self.pushPluginFCM unsubscribeFromTopic:topic];
-        [self successWithMessage:command.callbackId withMsg:[NSString stringWithFormat:@"Successfully unsubscribe from topic %@", topic]];
-    } else {
-        NSLog(@"[PushPlugin] There is no topic to unsubscribe");
-        [self successWithMessage:command.callbackId withMsg:@"There is no topic to unsubscribe"];
+    if (!self.pushPluginFCM.isFCMEnabled) {
+        NSLog(@"The 'unsubscribe' API not allowed. FCM is not enabled.");
+        [self successWithMessage:command.callbackId withMsg:@"The 'unsubscribe' API not allowed. FCM is not enabled."];
+        return;
     }
+
+    NSString* topic = [command argumentAtIndex:0];
+    if (topic == nil) {
+        NSLog(@"[PushPlugin] There is no topic to unsubscribe from.");
+        [self successWithMessage:command.callbackId withMsg:@"There is no topic to unsubscribe from."];
+        return;
+    }
+
+    [self.pushPluginFCM unsubscribeFromTopic:topic];
+    [self successWithMessage:command.callbackId withMsg:[NSString stringWithFormat:@"Successfully unsubscribe from topic %@", topic]];
 }
 
 - (void)init:(CDVInvokedUrlCommand *)command {

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -28,10 +28,6 @@
 #import "PushPluginSettings.h"
 #import "AppDelegate+notification.h"
 
-@import Firebase;
-@import FirebaseCore;
-@import FirebaseMessaging;
-
 @interface PushPlugin ()
 
 @property (nonatomic, strong) PushPluginFCM *pushPluginFCM;
@@ -128,7 +124,10 @@
     } else {
         NSLog(@"[PushPlugin] VoIP missing or false");
         if ([self.pushPluginFCM isFCMEnabled]) {
-            [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(setFCMTokenWithCompletion) name:FIRMessagingRegistrationTokenRefreshedNotification object:nil];
+            [[NSNotificationCenter defaultCenter] addObserver:self
+                                                     selector:@selector(setFCMTokenWithCompletion)
+                                                         name:[PushPluginFCM pushPluginFCMMessagingRegistrationTokenRefreshedNotification]
+                                                       object:nil];
         }
 
         [self.commandDelegate runInBackground:^ {

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -182,34 +182,26 @@
         NSLog(@"[PushPlugin] Unexpected call to didRegisterForRemoteNotificationsWithDeviceToken, ignoring: %@", deviceToken);
         return;
     }
+
     NSLog(@"[PushPlugin] register success: %@", deviceToken);
 
     if ([self.pushPluginFCM isFCMEnabled]) {
         [[FIRMessaging messaging] setAPNSToken:deviceToken];
         [self setFCMTokenWithCompletion];
+    } else {
+        [self registerWithToken:[self convertTokenToString:deviceToken]];
     }
+}
 
+- (NSString *)convertTokenToString:(NSData *)deviceToken {
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
     // [deviceToken description] is like "{length = 32, bytes = 0xd3d997af 967d1f43 b405374a 13394d2f ... 28f10282 14af515f }"
-    NSString *token = [self hexadecimalStringFromData:deviceToken];
+    return [self hexadecimalStringFromData:deviceToken];
 #else
     // [deviceToken description] is like "<124686a5 556a72ca d808f572 00c323b9 3eff9285 92445590 3225757d b83967be>"
-    NSString *token = [[[[deviceToken description] stringByReplacingOccurrencesOfString:@"<"withString:@""]
+    return [[[[deviceToken description] stringByReplacingOccurrencesOfString:@"<"withString:@""]
                         stringByReplacingOccurrencesOfString:@">" withString:@""]
                        stringByReplacingOccurrencesOfString: @" " withString: @""];
-#endif
-
-#if !TARGET_IPHONE_SIMULATOR
-    // Check what Notifications the user has turned on.  We registered for all three, but they may have manually disabled some or all of them.
-
-    UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
-    __weak PushPlugin *weakSelf = self;
-    [center getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings * _Nonnull settings) {
-
-        if(![self.pushPluginFCM isFCMEnabled]) {
-            [weakSelf registerWithToken: token];
-        }
-    }];
 #endif
 }
 

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -186,7 +186,7 @@
     NSLog(@"[PushPlugin] register success: %@", deviceToken);
 
     if ([self.pushPluginFCM isFCMEnabled]) {
-        [[FIRMessaging messaging] setAPNSToken:deviceToken];
+        [self.pushPluginFCM setAPNSToken:deviceToken];
         [self setFCMTokenWithCompletion];
     } else {
         [self registerWithToken:[self convertTokenToString:deviceToken]];

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -52,7 +52,7 @@
     self.pushPluginFCM = [[PushPluginFCM alloc] initWithGoogleServicePlist];
 
     if([self.pushPluginFCM isFCMEnabled]) {
-        [self.pushPluginFCM configureFirebase];
+        [self.pushPluginFCM configure];
     }
 }
 

--- a/src/ios/PushPluginFCM.h
+++ b/src/ios/PushPluginFCM.h
@@ -8,6 +8,7 @@
 - (instancetype)initWithGoogleServicePlist;
 
 - (void)configure;
+- (void)setAPNSToken:(NSData *)token;
 - (void)setTokenWithCompletion:(void (^)(NSString *token))completion;
 
 - (void)subscribeToTopic:(NSString *)topic;

--- a/src/ios/PushPluginFCM.h
+++ b/src/ios/PushPluginFCM.h
@@ -1,4 +1,6 @@
 #import <Foundation/Foundation.h>
+#import <Cordova/CDVPlugin.h>
+
 @import Firebase;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -6,20 +8,17 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PushPluginFCM : NSObject
 
 @property (nonatomic, assign) BOOL isFCMEnabled;
+@property (nonatomic, strong) NSString *callbackId;
 
 - (instancetype)initWithGoogleServicePlist;
 
-- (void)configure;
-- (void)setAPNSToken:(NSData *)token;
-- (void)setTokenWithCompletion:(void (^)(NSString *token))completion;
+- (void)configure:(id <CDVCommandDelegate>)commandDelegate;
+- (void)configureTokens:(NSData *)token;
 
 - (void)subscribeToTopic:(NSString *)topic;
-- (void)subscribeToTopics:(NSArray *)topics;
 
 - (void)unsubscribeFromTopic:(NSString *)topic;
 - (void)unsubscribeFromTopics:(NSArray *)topics;
-
-+ (NSNotificationName)pushPluginFCMMessagingRegistrationTokenRefreshedNotification;
 
 @end
 

--- a/src/ios/PushPluginFCM.h
+++ b/src/ios/PushPluginFCM.h
@@ -6,5 +6,6 @@
 @property (nonatomic, assign) BOOL isFCMEnabled;
 
 - (instancetype)initWithGoogleServicePlist;
+- (void)configureFirebase;
 
 @end

--- a/src/ios/PushPluginFCM.h
+++ b/src/ios/PushPluginFCM.h
@@ -1,6 +1,8 @@
 #import <Foundation/Foundation.h>
 @import Firebase;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface PushPluginFCM : NSObject
 
 @property (nonatomic, assign) BOOL isFCMEnabled;
@@ -17,4 +19,8 @@
 - (void)unsubscribeFromTopic:(NSString *)topic;
 - (void)unsubscribeFromTopics:(NSArray *)topics;
 
++ (NSNotificationName)pushPluginFCMMessagingRegistrationTokenRefreshedNotification;
+
 @end
+
+NS_ASSUME_NONNULL_END

--- a/src/ios/PushPluginFCM.h
+++ b/src/ios/PushPluginFCM.h
@@ -1,0 +1,10 @@
+#import <Foundation/Foundation.h>
+@import Firebase;
+
+@interface PushPluginFCM : NSObject
+
+@property (nonatomic, assign) BOOL isFCMEnabled;
+
+- (instancetype)initWithGoogleServicePlist;
+
+@end

--- a/src/ios/PushPluginFCM.h
+++ b/src/ios/PushPluginFCM.h
@@ -6,6 +6,13 @@
 @property (nonatomic, assign) BOOL isFCMEnabled;
 
 - (instancetype)initWithGoogleServicePlist;
+
 - (void)configureFirebase;
+
+- (void)subscribeToTopic:(NSString *)topic;
+- (void)subscribeToTopics:(NSArray *)topics;
+
+- (void)unsubscribeFromTopic:(NSString *)topic;
+- (void)unsubscribeFromTopics:(NSArray *)topics;
 
 @end

--- a/src/ios/PushPluginFCM.h
+++ b/src/ios/PushPluginFCM.h
@@ -7,7 +7,7 @@
 
 - (instancetype)initWithGoogleServicePlist;
 
-- (void)configureFirebase;
+- (void)configure;
 - (void)setTokenWithCompletion:(void (^)(NSString *token))completion;
 
 - (void)subscribeToTopic:(NSString *)topic;

--- a/src/ios/PushPluginFCM.h
+++ b/src/ios/PushPluginFCM.h
@@ -8,6 +8,7 @@
 - (instancetype)initWithGoogleServicePlist;
 
 - (void)configureFirebase;
+- (void)setTokenWithCompletion:(void (^)(NSString *token))completion;
 
 - (void)subscribeToTopic:(NSString *)topic;
 - (void)subscribeToTopics:(NSArray *)topics;

--- a/src/ios/PushPluginFCM.m
+++ b/src/ios/PushPluginFCM.m
@@ -28,7 +28,7 @@
     return self;
 }
 
-- (void)configureFirebase {
+- (void)configure {
     NSLog(@"[PushPlugin] Configuring Firebase App for FCM");
     [FIRApp configure];
 }

--- a/src/ios/PushPluginFCM.m
+++ b/src/ios/PushPluginFCM.m
@@ -27,4 +27,9 @@
     return self;
 }
 
+- (void)configureFirebase {
+    NSLog(@"[PushPlugin] Configuring Firebase App for FCM");
+    [FIRApp configure];
+}
+
 @end

--- a/src/ios/PushPluginFCM.m
+++ b/src/ios/PushPluginFCM.m
@@ -100,4 +100,8 @@
     NSLog(@"[PushPlugin] Successfully unsubscribed from topic %@", topic);
 }
 
++ (NSNotificationName)pushPluginFCMMessagingRegistrationTokenRefreshedNotification {
+    return FIRMessagingRegistrationTokenRefreshedNotification;
+}
+
 @end

--- a/src/ios/PushPluginFCM.m
+++ b/src/ios/PushPluginFCM.m
@@ -1,0 +1,30 @@
+#import "PushPluginFCM.h"
+
+@implementation PushPluginFCM
+
+- (instancetype)initWithGoogleServicePlist {
+    self = [super init];
+    if (self) {
+        NSString *googleServicePath = [[NSBundle mainBundle] pathForResource:@"GoogleService-Info" ofType:@"plist"];
+        NSDictionary *googleServicePlist = [[NSDictionary alloc] initWithContentsOfFile:googleServicePath];
+
+        if (googleServicePlist != nil) {
+            NSString *fcmSenderId = [googleServicePlist objectForKey:@"GCM_SENDER_ID"];
+            BOOL isGcmEnabled = [[googleServicePlist valueForKey:@"IS_GCM_ENABLED"] boolValue];
+
+            if (isGcmEnabled && fcmSenderId != nil) {
+                self.isFCMEnabled = YES;
+                NSLog(@"[PushPlugin] FCM is enabled and Sender ID is available.");
+            } else {
+                self.isFCMEnabled = NO;
+                NSLog(@"[PushPlugin] FCM is not enabled or Sender ID is missing.");
+            }
+        } else {
+            self.isFCMEnabled = NO;
+            NSLog(@"[PushPlugin] Could not locate GoogleService-Info.plist.");
+        }
+    }
+    return self;
+}
+
+@end

--- a/src/ios/PushPluginFCM.m
+++ b/src/ios/PushPluginFCM.m
@@ -32,4 +32,48 @@
     [FIRApp configure];
 }
 
+- (void)subscribeToTopics:(NSArray *)topics {
+    if(!topics) {
+        NSLog(@"[PushPlugin] There are no topics to subscribe to.");
+        return;
+    }
+
+    for (NSString *topic in topics) {
+        [self subscribeToTopic:topic];
+    }
+}
+
+- (void)subscribeToTopic:(NSString *)topic {
+    if (!topic) {
+        NSLog(@"[PushPlugin] There is no topic to subscribe to.");
+        return;
+    }
+
+    NSLog(@"[PushPlugin] Subscribing to topic: %@", topic);
+    [[FIRMessaging messaging] subscribeToTopic:topic];
+    NSLog(@"[PushPlugin] Successfully subscribed to topic %@", topic);
+}
+
+- (void)unsubscribeFromTopics:(NSArray *)topics {
+    if(!topics) {
+        NSLog(@"[PushPlugin] There are no topics to unsubscribe from.");
+        return;
+    }
+
+    for (NSString *topic in topics) {
+        [self unsubscribeFromTopic:topic];
+    }
+}
+
+- (void)unsubscribeFromTopic:(NSString *)topic {
+    if (!topic) {
+        NSLog(@"[PushPlugin] There is no topic to unsubscribe from.");
+        return;
+    }
+
+    NSLog(@"[PushPlugin] Unsubscribing from topic: %@", topic);
+    [[FIRMessaging messaging] unsubscribeFromTopic:topic];
+    NSLog(@"[PushPlugin] Successfully unsubscribed from topic %@", topic);
+}
+
 @end

--- a/src/ios/PushPluginFCM.m
+++ b/src/ios/PushPluginFCM.m
@@ -1,4 +1,5 @@
 #import "PushPluginFCM.h"
+#import "PushPluginSettings.h"
 
 @implementation PushPluginFCM
 
@@ -30,6 +31,24 @@
 - (void)configureFirebase {
     NSLog(@"[PushPlugin] Configuring Firebase App for FCM");
     [FIRApp configure];
+}
+
+- (void)setTokenWithCompletion:(void (^)(NSString *token))completion {
+#if TARGET_IPHONE_SIMULATOR
+    NSLog(@"[PushPlugin] Detected simulator. Will register an FCM token but pushing to simulator is not possible.");
+#endif
+
+    [[FIRMessaging messaging] tokenWithCompletion:^(NSString *token, NSError *error) {
+        if (error != nil) {
+            NSLog(@"[PushPlugin] Error getting FCM registration token: %@", error);
+        } else {
+            NSLog(@"[PushPlugin] FCM registration token: %@", token);
+            [self subscribeToTopics:[PushPluginSettings sharedInstance].fcmTopics];
+            if (completion) {
+                completion(token);
+            }
+        }
+    }];
 }
 
 - (void)subscribeToTopics:(NSArray *)topics {

--- a/src/ios/PushPluginFCM.m
+++ b/src/ios/PushPluginFCM.m
@@ -33,6 +33,11 @@
     [FIRApp configure];
 }
 
+- (void)setAPNSToken:(NSData *)token {
+    NSLog(@"[PushPlugin] Setting APNS Token for Firebase App");
+    [[FIRMessaging messaging] setAPNSToken:token];
+}
+
 - (void)setTokenWithCompletion:(void (^)(NSString *token))completion {
 #if TARGET_IPHONE_SIMULATOR
     NSLog(@"[PushPlugin] Detected simulator. Will register an FCM token but pushing to simulator is not possible.");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Closes #285

This PR would replace #285. This PR does not upgrade to 10.24.0 as #285 does but a separate PR would handle the version upgrade.

Extracts all FCM related logic to its own class.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Improve separation, maintainability, & encapsulation between FCM and non FCM code.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Build
- Run on Simulator
  - Drop APNs payloads
- Run on Device
  - Pushed notification through FCM console 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
