### PR TITLE
fix(ios): on notification event payload & stop background task

### DIFF
--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -624,16 +624,21 @@
 - (void) finish:(CDVInvokedUrlCommand *)command {
     [self.commandDelegate runInBackground:^ {
         NSString* notId = [command.arguments objectAtIndex:0];
-        NSLog(@"[PushPlugin] The 'finish' API was triggered for notId: %@", notId);
 
-        dispatch_async(dispatch_get_main_queue(), ^{
-            NSLog(@"[PushPlugin] Creating timer scheduled for notId: %@", notId);
-            [NSTimer scheduledTimerWithTimeInterval:0.1
-                                             target:self
-                                           selector:@selector(stopBackgroundTask:)
-                                           userInfo:notId
-                                            repeats:NO];
-        });
+        if (notId == nil || [notId isKindOfClass:[NSNull class]]) {
+            // @todo review "didReceiveNotificationResponse"
+            NSLog(@"[PushPlugin] Skipping 'finish' API as notId is unavailable.");
+        } else {
+            NSLog(@"[PushPlugin] The 'finish' API was triggered for notId: %@", notId);
+            dispatch_async(dispatch_get_main_queue(), ^{
+                NSLog(@"[PushPlugin] Creating timer scheduled for notId: %@", notId);
+                [NSTimer scheduledTimerWithTimeInterval:0.1
+                                                 target:self
+                                               selector:@selector(stopBackgroundTask:)
+                                               userInfo:notId
+                                                repeats:NO];
+            });
+        }
 
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -284,10 +284,21 @@
                 self.handlerObj = [NSMutableDictionary dictionaryWithCapacity:2];
             }
 
+            // Get the notId
             id notId = [userInfo objectForKey:@"notId"];
-            NSString *fallbackNotIdKey = [NSString stringWithFormat:@"pushplugin-handler-%f", [NSDate timeIntervalSinceReferenceDate]];
-            NSString *notIdKey = (notId != nil) ? notId : fallbackNotIdKey;
+            NSString *notIdKey = notId != nil ? [NSString stringWithFormat:@"%@", notId] : nil;
+
+            if (notIdKey == nil) {
+                // Create a unique notId
+                notIdKey = [NSString stringWithFormat:@"pushplugin-handler-%f", [NSDate timeIntervalSinceReferenceDate]];
+                // Add the unique notId to the userInfo. Passes to front-end payload.
+                [userInfo setValue:notIdKey forKey:@"notId"];
+                // Store the handler for the uniquly created notId.
+            }
+
             [self.handlerObj setObject:safeHandler forKey:notIdKey];
+
+            NSLog(@"[PushPlugin] Stored the completion handler for the background processing of notId %@", notIdKey);
 
             self.notificationMessage = userInfo;
             self.isInline = NO;
@@ -418,9 +429,18 @@
                 self.handlerObj = [NSMutableDictionary dictionaryWithCapacity:2];
             }
 
+            // Get the notId
             id notId = modifiedUserInfo[@"notId"];
-            NSString *fallbackNotIdKey = [NSString stringWithFormat:@"pushplugin-handler-%f", [NSDate timeIntervalSinceReferenceDate]];
-            NSString *notIdKey = (notId != nil) ? notId : fallbackNotIdKey;
+            NSString *notIdKey = notId != nil ? [NSString stringWithFormat:@"%@", notId] : nil;
+
+            if (notIdKey == nil) {
+                // Create a unique notId
+                notIdKey = [NSString stringWithFormat:@"pushplugin-handler-%f", [NSDate timeIntervalSinceReferenceDate]];
+                // Add the unique notId to the userInfo. Passes to front-end payload.
+                [modifiedUserInfo setValue:notIdKey forKey:@"notId"];
+                // Store the handler for the uniquly created notId.
+            }
+
             [self.handlerObj setObject:safeHandler forKey:notIdKey];
 
             NSLog(@"[PushPlugin] Stored the completion handler for the background processing of notId %@", notIdKey);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

**Updated `didReceiveNotificationResponse`:**

- Removed setting of `actionCallback` to `response.actionIdentifier`.
- Removed logic in the `UIApplicationStateInactive` state that decided whether to set the launch notification to the modified or unmodified `userInfo` containing the `response.actionIdentifier` on `actionCallback`.
- Added `applicationState` to `userInfo`, which is later used to decide whether `actionCallback` will be removed from the payload sent to the front end. See `notificationReceived` for reference.
- Since `applicationState` is now appended to `userInfo`, we can pass it up to the front on the `notification` event.
  - Note: I am currently removing it from the payload before returning, as we should confirm whether we can match this behavior on Android.

**Updated `notificationReceived` method:**

- Removed `actionCallback` from the payload when the application state is `inactive` or `background`. Removing it in these states aligns the behavior with Android.

**Other:**

- Updated the fallback notification ID of `handler` to become unique. Format `pushplugin-handler-<time>`

    Creating a unique fallback notId ensures each notification stores and executes its own completionHandler, preventing newer notifications from overwriting existing ones.
    
- Clean up `stopBackgroundTask` which is apart of the `push.finish` process.
- Make sure that the generated notId is stored and sent to the front-end to complete the `push.finish` properly.
- Skip the `push.finish` process when called and the notification came from `didReceiveNotificationResponse` Inactive State. The completion handler will already be triggered.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
 
Resolves #67
Resolves #94
Closes #186
Closes #251

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Try to match the same behavior with Android

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Pushed two types of APNs payloads:**

1. Payload without `actionCallback`
2. Payload with  `actionCallback`

**Tested the following cases:**

- App in active (foreground) state.
- App in background state.
- App in inactive (closed) state.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
