### PR TITLE
fix(ios): run setApplicationIconBadgeNumber on main thread

### DIFF
--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -126,7 +126,9 @@
             self.forceShow = [settings forceShowEnabled];
             self.clearBadge = [settings clearBadgeEnabled];
             if (self.clearBadge) {
-                [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
+                });
             }
 
             UNAuthorizationOptions authorizationOptions = UNAuthorizationOptionNone;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fixes an issue where `setApplicationIconBadgeNumber` was not running on the main thread. When this method is called on the wrong thread, Xcode displays the following error, and the app may also crash.

This issue can be reproduced by setting the `clearBadge` property to `true` when initializing the Push Plugin.

```
Main Thread Checker: UI API called on a background thread: -[UIApplication setApplicationIconBadgeNumber:]
PID: 0000, TID: 0000, Thread name: (none), Queue name: com.apple.root.default-qos, QoS: 0
Backtrace:
4   cordovaTest.debug.dylib             0x0000000000000000 __19-[PushPlugin init:]_block_invoke.54 + 208
5   libdispatch.dylib                   0x0000000000000000 _dispatch_call_block_and_release + 24
6   libdispatch.dylib                   0x0000000000000000 _dispatch_client_callout + 16
7   libdispatch.dylib                   0x0000000000000000 _dispatch_queue_override_invoke + 1320
8   libdispatch.dylib                   0x0000000000000000 _dispatch_root_queue_drain + 372
9   libdispatch.dylib                   0x0000000000000000 _dispatch_worker_thread2 + 256
10  libsystem_pthread.dylib             0x0000000000000000 _pthread_wqthread + 224
11  libsystem_pthread.dylib             0x0000000000000000 start_wqthread + 8
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

n/a

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Resolves the error and prevents potential app crashes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Built Cordova sample app before and after change.
- Have the `clearBadge` property set to `true`.
- Monitor the output in Xcode logs.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
