### PR TITLE
chore: revert back to AppDelegate

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -116,13 +116,13 @@
       <string>production</string>
     </config-file>
 
-    <source-file src="src/ios/CDVAppDelegate+notification.m"/>
+    <source-file src="src/ios/AppDelegate+PushPlugin.m"/>
     <source-file src="src/ios/PushPlugin.m"/>
     <source-file src="src/ios/PushPluginConstants.m"/>
     <source-file src="src/ios/PushPluginFCM.m"/>
     <source-file src="src/ios/PushPluginSettings.m"/>
 
-    <header-file src="src/ios/CDVAppDelegate+notification.h"/>
+    <header-file src="src/ios/AppDelegate+PushPlugin.h"/>
     <header-file src="src/ios/PushPlugin.h"/>
     <source-file src="src/ios/PushPluginConstants.h"/>
     <header-file src="src/ios/PushPluginFCM.h"/>

--- a/src/ios/AppDelegate+PushPlugin.h
+++ b/src/ios/AppDelegate+PushPlugin.h
@@ -1,14 +1,14 @@
 //
-//  CDVAppDelegate+notification.h
+//  AppDelegate+PushPlugin.h
 //
 //  Created by Robert Easterday on 10/26/12.
 //
 
-#import <Cordova/CDVAppDelegate.h>
+#import "AppDelegate.h"
 
 @import UserNotifications;
 
-@interface CDVAppDelegate (notification) <UNUserNotificationCenterDelegate>
+@interface AppDelegate (PushPlugin) <UNUserNotificationCenterDelegate>
 
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error;

--- a/src/ios/AppDelegate+PushPlugin.m
+++ b/src/ios/AppDelegate+PushPlugin.m
@@ -1,15 +1,15 @@
 //
-//  CDVAppDelegate+notification.m
+//  AppDelegate+PushPlugin.m
 //
 //  Created by Robert Easterday on 10/26/12.
 //
 
-#import "CDVAppDelegate+notification.h"
+#import "AppDelegate+PushPlugin.h"
 #import "PushPlugin.h"
 #import "PushPluginConstants.h"
 #import <objc/runtime.h>
 
-@implementation CDVAppDelegate (notification)
+@implementation AppDelegate (PushPlugin)
 
 // its dangerous to override a method from within a category.
 // Instead we will use method swizzling. we set this up in the load call.
@@ -34,10 +34,10 @@
     });
 }
 
-- (CDVAppDelegate *)pushPluginSwizzledInit {
+- (AppDelegate *)pushPluginSwizzledInit {
     UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
     center.delegate = self;
-    // This actually calls the original init method over in CDVAppDelegate. Equivilent to calling super
+    // This actually calls the original init method over in AppDelegate. Equivilent to calling super
     // on an overrided method, this is not recursive, although it appears that way. neat huh?
     return [self pushPluginSwizzledInit];
 }

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -24,7 +24,6 @@
  */
 
 #import "PushPlugin.h"
-#import "CDVAppDelegate+notification.h"
 #import "PushPluginConstants.h"
 #import "PushPluginFCM.h"
 #import "PushPluginSettings.h"
@@ -350,7 +349,7 @@
     UIApplicationState applicationState = [UIApplication sharedApplication].applicationState;
     NSNumber *applicationStateNumber = @((int)applicationState);
 
-    // The original notification that comes from the CDVAppDelegate's willPresentNotification.
+    // The original notification that comes from the AppDelegate's willPresentNotification.
     UNNotification *originalNotification = notification.userInfo[@"notification"];
     NSDictionary *originalUserInfo = originalNotification.request.content.userInfo;
     NSMutableDictionary *modifiedUserInfo = [originalUserInfo mutableCopy];
@@ -399,7 +398,7 @@
 }
 
 - (void)didReceiveNotificationResponse:(NSNotification *)notification {
-    // The original response that comes from the CDVAppDelegate's didReceiveNotificationResponse.
+    // The original response that comes from the AppDelegate's didReceiveNotificationResponse.
     UNNotificationResponse *response = notification.userInfo[@"response"];
 
     NSLog(@"[PushPlugin] Notification was received. (actionIdentifier %@, notification: %@)",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Reverting to an `AppDelegate` extension instead of `CDVAppDelegate`.

It seems that converting to a `CDVAppDelegate` extension didn't work as expected when other plugins were installed that also defined their own `AppDelegate` extensions with methods required by this plugin.

For example, `cordova-plugin-firebasex`.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

n/a

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Reverting back `AppDelegate`. See the "Description" section for context.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Created a project with `cordova-plugin-firebasex` to confirm that the methods defined in this plugin are triggered again.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
