### PR TITLE
fix: add clearNotification to typescript definitions

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -107,9 +107,17 @@ declare namespace PhonegapPluginPush {
 		/**
 		 * Tells the OS to clear all notifications from the Notification Center
 		 * @param successHandler Is called when the api successfully clears the notifications.
-		 * @param errorHandler Is called when the api encounters an error when attempting to clears the notifications.
+		 * @param errorHandler Is called when the api encounters an error when attempting to clear the notifications.
 		 */
 		clearAllNotifications(successHandler: () => any, errorHandler: () => any): void
+
+		/**
+		 * Tells the OS to clear the notification that corresponds to the id argument, from the Notification Center
+		 * @param successHandler Is called when the api successfully clears the notification.
+		 * @param errorHandler Is called when the api encounters an error when attempting to clear the notification.
+		 * @param id The ID of the notification that will be cleared.
+		 */
+		clearNotification(successHandler: () => any, errorHandler: () => any, id?: number): void
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add missing `clearNotification` to typescript definitions.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Resolves #85 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

n/a

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
