### PR TITLE
fix(android): getCircleBitmap not displaying image

### DIFF
--- a/src/android/com/adobe/phonegap/push/FCMService.kt
+++ b/src/android/com/adobe/phonegap/push/FCMService.kt
@@ -1012,23 +1012,25 @@ class FCMService : FirebaseMessagingService() {
       Bitmap.Config.ARGB_8888
     )
 
+    val canvas = Canvas(output)
+    canvas.drawARGB(0, 0, 0, 0)
+
     val paint = Paint().apply {
       isAntiAlias = true
       color = Color.RED
-      xfermode = PorterDuffXfermode(PorterDuff.Mode.SRC_IN)
     }
 
-    Canvas(output).apply {
-      drawARGB(0, 0, 0, 0)
+    val cx = (bitmap.width / 2).toFloat()
+    val cy = (bitmap.height / 2).toFloat()
+    val radius = minOf(cx, cy)
 
-      val cx = (bitmap.width / 2).toFloat()
-      val cy = (bitmap.height / 2).toFloat()
-      val radius = if (cx < cy) cx else cy
-      val rect = Rect(0, 0, bitmap.width, bitmap.height)
+    canvas.drawCircle(cx, cy, radius, paint)
 
-      drawCircle(cx, cy, radius, paint)
-      drawBitmap(bitmap, rect, rect, paint)
-    }
+    // Set the Xfermode to SRC_IN after drawing the circle,
+    // so that the bitmap will clip correctly inside the circle.
+    paint.xfermode = PorterDuffXfermode(PorterDuff.Mode.SRC_IN)
+
+    canvas.drawBitmap(bitmap, 0f, 0f, paint)
 
     bitmap.recycle()
     return output


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Set the `xfermode` after the circle is drawn so that the source bitmap is clipped correctly inside the circle.

Previously, the `xfermode` was applied during the creation of the paint object, which caused a timing issue. As a result, the image was not clipped inside the circle properly, making it appear as though there was no image.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Resolves #199 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Fix the issue where `getCircleBitmap` was not displaying the image correctly.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Build app
- Tested pushing payload before and after changes

Payload contained

- `image` pointing to a square image on web (square so I can confirm the circle effect)
- `image-type` set to `circle`

I also tried without setting the `image-type` to confirm default behavior.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
