### PR TITLE
fix(push): fix payload content-available crash

### DIFF
--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -33,7 +33,7 @@
 @property (nonatomic, strong) PushPluginFCM *pushPluginFCM;
 
 @property (nonatomic, strong) NSDictionary *launchNotification;
-@property (nonatomic, strong) NSDictionary *notificationMessage;
+@property (nonatomic, strong) NSMutableDictionary *notificationMessage;
 @property (nonatomic, strong) NSMutableDictionary *handlerObj;
 @property (nonatomic, strong) UNNotification *previousNotification;
 
@@ -300,7 +300,7 @@
 
             NSLog(@"[PushPlugin] Stored the completion handler for the background processing of notId %@", notIdKey);
 
-            self.notificationMessage = userInfo;
+            self.notificationMessage = [userInfo mutableCopy];
             self.isInline = NO;
             [self notificationReceived];
         } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Changes notificationMessage from NSDictionary to NSMutableDictionary and the content-availble hander changes userinfo to a mutableCopy
## Description
<!--- Describe your changes in detail -->

same as above

## Related Issue
fixes  #314 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This fixes the app crashing at https://github.com/havesource/cordova-plugin-push/blob/12a5b71cb381c8e0ad0370a771ac523dc46de7a3/src/ios/PushPlugin.m#L497

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

receive a push payload with content-available:1
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
