### PR TITLE
fix(ios): reset flags & stored message after processing notification received

### DIFF
--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -338,8 +338,6 @@
     }
 
     if (self.launchNotification) {
-        self.isInline = NO;
-        self.coldstart = NO;
         self.notificationMessage = self.launchNotification;
         self.launchNotification = nil;
         [self performSelectorOnMainThread:@selector(notificationReceived) withObject:self waitUntilDone:NO];
@@ -560,10 +558,11 @@
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:message];
         [pluginResult setKeepCallbackAsBool:YES];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackId];
-
-        self.coldstart = NO;
-        self.notificationMessage = nil;
     }
+
+    self.isInline = NO;
+    self.coldstart = NO;
+    self.notificationMessage = nil;
 }
 
 - (void)clearNotification:(CDVInvokedUrlCommand *)command {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Reset flags and stored message after the received notification is processed and sent to the "notification" event.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Resolves #316

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Fix issue where the notification event always displays `coldstart` as `false`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Built app and sent a test notification push while app is open, closed, or in background.

Tested with most basic payload:

```json
{
  "aps": {
    "alert": "Sample message"
  }
}
```

Results:

App Foreground:

```json
{
  "message": "Sample message",
  "additionalData": {
    "foreground": true,
    "coldstart": false
  }
}
```

App Background (Tapped on Notification Banner):

```json
{
  "message": "Sample message",
  "additionalData": {
    "foreground": false,
    "coldstart": true
  }
}
```

App Closed (Tapped on Notification Banner):

```json
{
  "message": "Sample message",
  "additionalData": {
    "foreground": false,
    "coldstart": true
  }
}
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
