### PR TITLE
fix(ios): exclude configure if FirApp is already configured

### DIFF
--- a/src/ios/PushPluginFCM.m
+++ b/src/ios/PushPluginFCM.m
@@ -37,7 +37,9 @@
 
 - (void)configure:(id <CDVCommandDelegate>)commandDelegate {
     NSLog(@"[PushPlugin] Configuring Firebase App for FCM");
-    [FIRApp configure];
+    if(![FIRApp defaultApp]) {
+        [FIRApp configure];
+    }
 
     self.commandDelegate = commandDelegate;
 }


### PR DESCRIPTION
Exclude configure if FirApp is already configured by an other library/

## Description
Using your package, especially your latest release 5.0.0, I encountered an error with Firebase being already configured. I used the FirApp verification from an other Cordova Plugin, tested it in my project and it works great.
