### PR TITLE
fix(android): prevent permission dialog appearing when already denied

### DIFF
--- a/src/android/com/adobe/phonegap/push/PushPlugin.kt
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.kt
@@ -441,9 +441,9 @@ class PushPlugin : CordovaPlugin() {
     pushContext = callbackContext
     pluginInitData = data;
 
-    var hasPermission = checkForPostNotificationsPermission()
-    if (!hasPermission)
+    if (!checkForPostNotificationsPermission()) {
       return
+    }
 
     cordova.threadPool.execute(Runnable {
       Log.v(TAG, formatLogMessage("Data=$data"))
@@ -612,8 +612,13 @@ class PushPlugin : CordovaPlugin() {
 
   private fun checkForPostNotificationsPermission(): Boolean {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-      if (!PermissionHelper.hasPermission(this, Manifest.permission.POST_NOTIFICATIONS))
-      {
+      if (!PermissionHelper.hasPermission(this, Manifest.permission.POST_NOTIFICATIONS)) {
+        if (ActivityCompat.shouldShowRequestPermissionRationale(
+            activity,
+            Manifest.permission.POST_NOTIFICATIONS
+          )) {
+          return false
+        }
         PermissionHelper.requestPermission(
           this,
           REQ_CODE_INITIALIZE_PLUGIN,
@@ -622,7 +627,6 @@ class PushPlugin : CordovaPlugin() {
         return false
       }
     }
-
     return true
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Prevent second permission dialog from appearing on second launch if user already selected "Don't allow".

## Description
<!--- Describe your changes in detail -->

If the user selects "Don't allow" for the push notification permission, it is expected that the notification dialog will not reappear on subsequent launches asking the same question.

It is assumed that the user's decision reflects their intent.

If they made a mistake, they can go to the app settings to manually enable the permission.

Additionally, the unusual behavior of the permission dialog reappearing occurs only on the second launch; on the third or later launches, the dialog does not appear.

The changes in this PR ensure that the decision made by the app user is acknowledged and the permission will not be requested again.

This behavior was achieved by adding a call to `shouldShowRequestPermissionRationale` before invoking the `requestPermissions` method, which aligns with the guidance provided in the Android documentation.

Reference: [Android Documentation - requestPermissions](https://developer.android.com/reference/androidx/core/app/ActivityCompat#requestPermissions(android.app.Activity,%20java.lang.String[],%20int))

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

n/a

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Built Android app
- Ran app
- Click "Don't allow" for the notification permission
- Close app
- Open app
- Confirmed that the dialog does not display again.

Additional Test:

- Go to app settings
- Enable notification permission
- Re-open app
- Confirm registration completed

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
