### PR TITLE
fix(ios): revert accidental change to category "callback"

### DIFF
--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -413,6 +413,7 @@
     NSDictionary *originalUserInfo = response.notification.request.content.userInfo;
     NSMutableDictionary *modifiedUserInfo = [originalUserInfo mutableCopy];
     [modifiedUserInfo setObject:applicationStateNumber forKey:@"applicationState"];
+    [modifiedUserInfo setObject:response.actionIdentifier forKey:@"actionCallback"];
 
     switch (applicationState) {
         case UIApplicationStateActive:
@@ -491,7 +492,8 @@
         // Remove "actionCallback" when application state is not foreground. Only applied to foreground.
         NSNumber *applicationStateNumber = mutableNotificationMessage[@"applicationState"];
         UIApplicationState applicationState = (UIApplicationState)[applicationStateNumber intValue];
-        if (applicationState != UIApplicationStateActive) {
+        if (applicationState != UIApplicationStateActive
+            && [[mutableNotificationMessage objectForKey:@"actionCallback"] isEqualToString:UNNotificationDefaultActionIdentifier]) {
             [mutableNotificationMessage removeObjectForKey:@"actionCallback"];
         }
         // @todo do not sent applicationState data to front for now. Figure out if we can add

--- a/src/ios/PushPluginSettings.m
+++ b/src/ios/PushPluginSettings.m
@@ -117,7 +117,7 @@
         return nil;
     }
 
-    NSString *identifier = [dictionary objectForKey:@"identifier"];
+    NSString *identifier = [dictionary objectForKey:@"callback"];
     NSString *title = [dictionary objectForKey:@"title"];
 
     if (!title || !identifier) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Fix an accidental breaking property name change from `callback` to `identifier`.
Fix issue where category's `callback` was not being property set and triggered.

## Description
<!--- Describe your changes in detail -->

In the documentation and typings, the `CategoryActionData` object should include a key named `callback`.

On iOS, the native code refers to `callback` as `identifier`. Because of this, the native implementation was mistakenly modified to extract the `callback` value using the incorrect key `identifier`.

This PR reverts the key back to `callback` to align with the documentation and typings.

The issue was discovered during testing of the typings.

Updated code to make sure that the actionCallback is not removed in cases where the value is not default.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

n/a

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Confirmed that the `callback` is triggered when clicking the category option.
- Tested the default, category, & actionCallback case while app state is in Foreground, Background, & Inactive

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
