### PR TITLE
fix(ios): dont trigger notificationReceived on app reload

### DIFF
--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -37,6 +37,7 @@
 @property (nonatomic, strong) NSMutableDictionary *handlerObj;
 @property (nonatomic, strong) UNNotification *previousNotification;
 
+@property (nonatomic, assign) BOOL isInitialized;
 @property (nonatomic, assign) BOOL isInline;
 @property (nonatomic, assign) BOOL clearBadge;
 @property (nonatomic, assign) BOOL forceShow;
@@ -152,6 +153,8 @@
             PKPushRegistry *pushRegistry = [[PKPushRegistry alloc] initWithQueue:dispatch_get_main_queue()];
             pushRegistry.delegate = self;
             pushRegistry.desiredPushTypes = [NSSet setWithObject:PKPushTypeVoIP];
+
+            self.isInitialized = YES;
         }];
     } else {
         NSLog(@"[PushPlugin] VoIP missing or false");
@@ -189,11 +192,13 @@
             [center setNotificationCategories:[settings categories]];
 
             // If there is a pending startup notification, we will delay to allow JS event handlers to setup
-            if (self.notificationMessage) {
+            if (self.notificationMessage && !self.isInitialized) {
                 dispatch_async(dispatch_get_main_queue(), ^{
                     [self performSelector:@selector(notificationReceived) withObject:nil afterDelay: 0.5];
                 });
             }
+
+            self.isInitialized = YES;
         }];
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Prevents the notification from triggering the notification event on app reload when a notification message exists.

## Description
<!--- Describe your changes in detail -->

Added the `isInitialized` flag as an additional parameter to determine if the app should trigger the `notificationReceived` method.

When the app launches and initializes for the first time, if a `notificationMessage` exists, it should be processed. This handles the case of tapping/opening a notification from the notification drawer while the app is inactive (closed/terminated).

If a notification is delivered and the app is reloaded using `window.location.reload()`, the plugin's `init` method is triggered again. This causes the `on('notification')` event to be triggered because the `notificationMessage` exists, which is incorrect behavior. The event should only be triggered by tapping on the notification.

Because `window.location.reload()` is possible, the `isInitialized` flag ensures that the event won't be triggered during an app reload.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

n/a

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Built app
- Pushed payload in all states
- Ensure that notification event is only triggered when the toast was tapped on
  - `forceShow` = `true` and `false` cases

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
