### PR TITLE
fix(ios): correctly set foreground flag when forceShow is enabled

### DIFF
--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -38,7 +38,7 @@
 @property (nonatomic, strong) UNNotification *previousNotification;
 
 @property (nonatomic, assign) BOOL isInitialized;
-@property (nonatomic, assign) BOOL isInline;
+@property (nonatomic, assign) BOOL isForeground;
 @property (nonatomic, assign) BOOL clearBadge;
 @property (nonatomic, assign) BOOL forceShow;
 @property (nonatomic, assign) BOOL coldstart;
@@ -161,7 +161,7 @@
 
         [self.commandDelegate runInBackground:^ {
             NSLog(@"[PushPlugin] register called");
-            self.isInline = NO;
+            self.isForeground = NO;
             self.forceShow = [settings forceShowEnabled];
             self.clearBadge = [settings clearBadgeEnabled];
             if (self.clearBadge) {
@@ -309,7 +309,7 @@
             NSLog(@"[PushPlugin] Stored the completion handler for the background processing of notId %@", notIdKey);
 
             self.notificationMessage = [mutableUserInfo copy];
-            self.isInline = NO;
+            self.isForeground = NO;
             [self notificationReceived];
         } else {
             NSLog(@"[PushPlugin] Application is not active, saving notification for later.");
@@ -388,7 +388,7 @@
     }
 
     self.notificationMessage = [modifiedUserInfo copy];
-    self.isInline = YES;
+    self.isForeground = YES;
 
     UNNotificationPresentationOptions presentationOption = UNNotificationPresentationOptionNone;
 
@@ -427,7 +427,7 @@
         {
             NSLog(@"[PushPlugin] App is active. Notification message set with: %@", modifiedUserInfo);
 
-            self.isInline = NO;
+            self.isForeground = YES;
             self.notificationMessage = [modifiedUserInfo copy];
             [self notificationReceived];
             if (completionHandler) {
@@ -440,6 +440,7 @@
             NSLog(@"[PushPlugin] App is inactive. Storing notification message for later launch with: %@", modifiedUserInfo);
 
             self.coldstart = YES;
+            self.isForeground = NO;
             self.launchNotification = [modifiedUserInfo copy];
             if (completionHandler) {
                 completionHandler();
@@ -478,7 +479,7 @@
 
             NSLog(@"[PushPlugin] Stored the completion handler for the background processing of notId %@", notIdKey);
 
-            self.isInline = NO;
+            self.isForeground = NO;
             self.notificationMessage = [modifiedUserInfo copy];
 
             [self performSelectorOnMainThread:@selector(notificationReceived) withObject:self waitUntilDone:NO];
@@ -547,7 +548,7 @@
             }
         }
 
-        if (self.isInline) {
+        if (self.isForeground) {
             [additionalData setObject:[NSNumber numberWithBool:YES] forKey:@"foreground"];
         } else {
             [additionalData setObject:[NSNumber numberWithBool:NO] forKey:@"foreground"];
@@ -567,7 +568,7 @@
         [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackId];
 
         self.coldstart = NO;
-        self.isInline = NO;
+        self.isForeground = NO;
         self.notificationMessage = nil;
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Fix an issue where the `notification` event payload's property `additionalData.foreground` is incorrectly set when the app is in the foreground and the `forceShow` option is enabled.

## Description
<!--- Describe your changes in detail -->

- Renamed the internal variable `isInline` to `isForeground`.
- Corrected the setting of `isForeground` in `didReceiveNotificationResponse` when the application state was `UIApplicationStateActive`. This should have been and is now set to `YES`.
- Explicitly define and set the `isForeground` to `NO` in the `didReceiveNotificationResponse` method when the application state is `UIApplicationStateInactive`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

n/a

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Built an application and tested the following:

**`foreShow = true` Test Case:**

- AppState: Foreground
  - `payload.additionalData.foreground` = `true`
  - `payload.additionalData.coldstart` = `false`
- AppState: Background
  - `payload.additionalData.foreground` = `false`
  - `payload.additionalData.coldstart` = `true`
- AppState: Inactive
  - `payload.additionalData.foreground` = `false`
  - `payload.additionalData.coldstart` = `true`

**`foreShow = false` Test Case:**

- AppState: Foreground
  - `payload.additionalData.foreground` = `true`
  - `payload.additionalData.coldstart` = `false`
- AppState: Background
  - `payload.additionalData.foreground` = `false`
  - `payload.additionalData.coldstart` = `true`
- AppState: Inactive
  - `payload.additionalData.foreground` = `false`
  - `payload.additionalData.coldstart` = `true`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
